### PR TITLE
feat!: improve error handling

### DIFF
--- a/crates/dts-core/src/error.rs
+++ b/crates/dts-core/src/error.rs
@@ -1,6 +1,9 @@
 //! Defines the `Error` and `Result` types used by this crate.
 
 use crate::{parsers::ParseError, transform::TransformError, Encoding};
+use std::error::Error as StdError;
+use std::fmt::Display;
+use std::io;
 use thiserror::Error;
 
 /// A type alias for `Result<T, Error>`.
@@ -12,7 +15,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub enum Error {
     /// Represents a generic error message.
     #[error("{0}")]
-    GenericError(String),
+    Message(String),
 
     /// Represents errors of operations that are not supported by a certain encoding.
     #[error("Operation is not supported for encoding `{0}`")]
@@ -28,7 +31,7 @@ pub enum Error {
 
     /// Represents generic IO errors.
     #[error(transparent)]
-    IoError(#[from] std::io::Error),
+    Io(#[from] io::Error),
 
     /// Represents an invalid glob pattern.
     #[error("Invalid glob pattern `{pattern}`")]
@@ -43,49 +46,124 @@ pub enum Error {
     #[error("Unable to fetch remote data source")]
     RequestError(#[from] ureq::Error),
 
-    /// Error emitted by serde_yaml.
-    #[error(transparent)]
-    YamlError(#[from] serde_yaml::Error),
-
-    /// Error emitted by serde_json.
-    #[error(transparent)]
-    JsonError(#[from] serde_json::Error),
-
-    /// Error emitted by json5.
-    #[error(transparent)]
-    Json5Error(#[from] json5::Error),
-
-    /// Serialization error emitted by toml.
-    #[error(transparent)]
-    TomlSerializeError(#[from] toml::ser::Error),
-
-    /// Deserialization error emitted by toml.
-    #[error(transparent)]
-    TomlDeserializeError(#[from] toml::de::Error),
-
-    /// Error emitted by csv.
-    #[error(transparent)]
-    CsvError(#[from] csv::Error),
-
     /// Indicates an error at a specific row of input or output data.
     #[error("Error at row index {0}: {1}")]
     CsvRowError(usize, String),
 
-    /// Error emitted by serde_qs.
+    /// Represents errors emitted by serializers and deserializers.
     #[error(transparent)]
-    QueryStringError(#[from] serde_qs::Error),
-
-    /// Error emitted by serde_xml.
-    #[error(transparent)]
-    XmlError(#[from] serde_xml_rs::Error),
-
-    /// Error emitted by hcl.
-    #[error(transparent)]
-    HclError(#[from] hcl::Error),
+    Serde(Box<dyn StdError + Send + Sync>),
 }
 
 impl Error {
-    pub(crate) fn new<S: ToString>(message: S) -> Self {
-        Self::GenericError(message.to_string())
+    pub(crate) fn new<T>(msg: T) -> Error
+    where
+        T: Display,
+    {
+        Error::Message(msg.to_string())
+    }
+
+    pub(crate) fn serde<E>(err: E) -> Error
+    where
+        E: Into<Box<dyn StdError + Send + Sync>>,
+    {
+        Error::Serde(err.into())
+    }
+
+    pub(crate) fn io<E>(err: E) -> Error
+    where
+        E: Into<io::Error>,
+    {
+        Error::Io(err.into())
+    }
+
+    pub(crate) fn glob_pattern<T>(pattern: T, source: glob::PatternError) -> Error
+    where
+        T: Display,
+    {
+        Error::GlobPatternError {
+            pattern: pattern.to_string(),
+            source,
+        }
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(err: serde_json::Error) -> Self {
+        if err.is_io() {
+            Error::io(err)
+        } else {
+            Error::serde(err)
+        }
+    }
+}
+
+impl From<serde_yaml::Error> for Error {
+    fn from(err: serde_yaml::Error) -> Self {
+        if let Some(source) = err.source() {
+            if let Some(io_err) = source.downcast_ref::<io::Error>() {
+                return Error::io(io_err.kind());
+            }
+        }
+
+        Error::serde(err)
+    }
+}
+
+impl From<json5::Error> for Error {
+    fn from(err: json5::Error) -> Self {
+        Error::serde(err)
+    }
+}
+
+impl From<toml::ser::Error> for Error {
+    fn from(err: toml::ser::Error) -> Self {
+        Error::serde(err)
+    }
+}
+
+impl From<toml::de::Error> for Error {
+    fn from(err: toml::de::Error) -> Self {
+        Error::serde(err)
+    }
+}
+
+impl From<csv::Error> for Error {
+    fn from(err: csv::Error) -> Self {
+        if err.is_io_error() {
+            match err.into_kind() {
+                csv::ErrorKind::Io(io_err) => Error::io(io_err),
+                _ => unreachable!(),
+            }
+        } else {
+            Error::serde(err)
+        }
+    }
+}
+
+impl From<serde_qs::Error> for Error {
+    fn from(err: serde_qs::Error) -> Self {
+        match err {
+            serde_qs::Error::Io(io_err) => Error::io(io_err),
+            other => Error::serde(other),
+        }
+    }
+}
+
+impl From<serde_xml_rs::Error> for Error {
+    fn from(err: serde_xml_rs::Error) -> Self {
+        match err {
+            serde_xml_rs::Error::Io { source } => Error::io(source),
+            other => Error::serde(other),
+        }
+    }
+}
+
+impl From<hcl::Error> for Error {
+    fn from(err: hcl::Error) -> Self {
+        match err {
+            hcl::Error::Io(io_err) => Error::io(io_err),
+            other => Error::serde(other),
+        }
     }
 }

--- a/crates/dts-core/src/lib.rs
+++ b/crates/dts-core/src/lib.rs
@@ -51,10 +51,7 @@ where
         let full_pattern = self.as_ref().join(pattern);
 
         glob::glob(&full_pattern.to_string_lossy())
-            .map_err(|e| Error::GlobPatternError {
-                pattern: full_pattern.to_string_lossy().into(),
-                source: e,
-            })?
+            .map_err(|err| Error::glob_pattern(full_pattern.display(), err))?
             .filter_map(|result| match result {
                 Ok(path) => path.is_file().then(|| Ok(path)),
                 Err(err) => Some(Err(err.into_error().into())),

--- a/crates/dts-core/src/parsers/error.rs
+++ b/crates/dts-core/src/parsers/error.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::fmt::{self, Display};
 use thiserror::Error;
 
 /// Error emitted by all parsers in this module.
@@ -10,8 +10,11 @@ pub struct ParseError {
 }
 
 impl ParseError {
-    pub(crate) fn new<S: ToString>(kind: ParseErrorKind, msg: S) -> Self {
-        Self {
+    pub(crate) fn new<T>(kind: ParseErrorKind, msg: T) -> ParseError
+    where
+        T: Display,
+    {
+        ParseError {
             kind,
             msg: msg.to_string(),
         }
@@ -27,11 +30,11 @@ pub enum ParseErrorKind {
     Gron,
 }
 
-impl fmt::Display for ParseErrorKind {
+impl Display for ParseErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::FlatKey => write!(f, "flat key"),
-            Self::Gron => write!(f, "gron"),
+            ParseErrorKind::FlatKey => write!(f, "flat key"),
+            ParseErrorKind::Gron => write!(f, "gron"),
         }
     }
 }

--- a/crates/dts-core/src/transform/error.rs
+++ b/crates/dts-core/src/transform/error.rs
@@ -1,4 +1,5 @@
 use crate::parsers::ParseError;
+use std::fmt::Display;
 use thiserror::Error;
 
 /// The error returned by all fallible operations within this module.
@@ -8,22 +9,51 @@ pub enum TransformError {
     /// Represents an unknown transformation key. This usually indicates incorrect user input.
     #[error("Unknown transformation `{0}`")]
     UnknownTransformation(String),
+
     /// A transformation requires a value.
     #[error("Transformation `{0}` requires a value")]
     ValueRequired(String),
+
     /// Represents a error while parsing the query of jsonpath filter transformation.
     #[error("Failed to parse JSONPath query:\n{0}")]
     JSONPathParseError(String),
-    /// Represents a parse error that happens during a transformation operation.
-    #[error("Parse error during data transformation")]
-    ParseError(#[from] ParseError),
+
     /// Represents an invalid sort order.
     #[error("Invalid sort order `{0}`")]
     InvalidSortOrder(String),
+
+    /// Represents a parse error that happens during a transformation operation.
+    #[error("Parse error during data transformation")]
+    ParseError(#[from] ParseError),
+
     /// Represents an error while compiling a regex.
     #[error(transparent)]
     RegexError(#[from] regex::Error),
+
     /// Represents an error while parsing an integer.
     #[error(transparent)]
     ParseIntError(#[from] std::num::ParseIntError),
+}
+
+impl TransformError {
+    pub(crate) fn invalid_sort_order<T>(order: T) -> Self
+    where
+        T: Display,
+    {
+        TransformError::InvalidSortOrder(order.to_string())
+    }
+
+    pub(crate) fn unknown_transformation<T>(trans: T) -> Self
+    where
+        T: Display,
+    {
+        TransformError::UnknownTransformation(trans.to_string())
+    }
+
+    pub(crate) fn value_required<T>(trans: T) -> Self
+    where
+        T: Display,
+    {
+        TransformError::ValueRequired(trans.to_string())
+    }
 }

--- a/crates/dts-core/src/transform/mod.rs
+++ b/crates/dts-core/src/transform/mod.rs
@@ -94,14 +94,14 @@ impl FromStr for Transformation {
                 "F" | "flatten-keys" => Self::FlattenKeys(value.map(|v| v.to_string())),
                 "j" | "jsonpath" => value
                     .map(|query| Self::JsonPath(query.to_string()))
-                    .ok_or_else(|| TransformError::ValueRequired(key.into()))?,
+                    .ok_or_else(|| TransformError::value_required(key))?,
                 "r" | "remove-empty-values" => Self::RemoveEmptyValues,
                 "m" | "deep-merge" => Self::DeepMerge,
                 "e" | "expand-keys" => Self::ExpandKeys,
                 "k" | "keys" => Self::Keys,
                 "d" | "delete-keys" => value
                     .map(|pattern| Self::DeleteKeys(pattern.to_string()))
-                    .ok_or_else(|| TransformError::ValueRequired(key.into()))?,
+                    .ok_or_else(|| TransformError::value_required(key))?,
                 "s" | "sort" => {
                     let sorter = match value {
                         Some(value) => ValueSorter::from_str(value)?,
@@ -110,7 +110,7 @@ impl FromStr for Transformation {
 
                     Self::Sort(sorter)
                 }
-                key => return Err(TransformError::UnknownTransformation(key.into())),
+                key => return Err(TransformError::unknown_transformation(key)),
             }
         };
 

--- a/crates/dts-core/src/transform/sort.rs
+++ b/crates/dts-core/src/transform/sort.rs
@@ -20,7 +20,7 @@ impl FromStr for Order {
         match s.to_lowercase().as_str() {
             "asc" => Ok(Order::Asc),
             "desc" => Ok(Order::Desc),
-            other => Err(TransformError::InvalidSortOrder(other.into())),
+            other => Err(TransformError::invalid_sort_order(other)),
         }
     }
 }

--- a/crates/dts/main.rs
+++ b/crates/dts/main.rs
@@ -10,7 +10,7 @@ use clap::Parser;
 use dts_core::{de::Deserializer, ser::Serializer};
 use dts_core::{transform, Encoding, Error, Sink, Source, Value};
 use rayon::prelude::*;
-use std::io::{BufReader, BufWriter};
+use std::io::{self, BufReader, BufWriter};
 
 fn deserialize(source: &Source, opts: &InputOptions) -> Result<Value> {
     let encoding = opts
@@ -64,7 +64,7 @@ fn serialize(sink: &Sink, value: &Value, opts: &OutputOptions) -> Result<()> {
 
     match ser.serialize(encoding, value) {
         Ok(()) => Ok(()),
-        Err(Error::IoError(e)) if e.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
+        Err(Error::Io(err)) if err.kind() == io::ErrorKind::BrokenPipe => Ok(()),
         Err(err) => Err(err),
     }
     .with_context(|| format!("Failed to serialize `{}` to `{}`", encoding, sink))

--- a/crates/hcl/src/de.rs
+++ b/crates/hcl/src/de.rs
@@ -85,11 +85,12 @@ impl<'de> Deserializer<'de> {
         let node = self.take_node()?;
         let span = node.as_span();
 
-        match node {
+        let res = match node {
             Node::Int(pair) => pair.as_str().parse().map_err(|_| Error::new("Invalid int")),
             _ => Err(Error::expected("int")),
-        }
-        .map_err(|e| e.with_span(span))
+        };
+
+        res.map_err(|err| err.with_span(span))
     }
 
     fn parse_float<T>(&mut self) -> Result<T>
@@ -99,14 +100,15 @@ impl<'de> Deserializer<'de> {
         let node = self.take_node()?;
         let span = node.as_span();
 
-        match node {
+        let res = match node {
             Node::Float(pair) => pair
                 .as_str()
                 .parse()
                 .map_err(|_| Error::new("Invalid float")),
             _ => Err(Error::expected("float")),
-        }
-        .map_err(|e| e.with_span(span))
+        };
+
+        res.map_err(|err| err.with_span(span))
     }
 
     fn parse_str(&mut self) -> Result<&'de str> {
@@ -120,7 +122,7 @@ impl<'de> Deserializer<'de> {
         let node = self.take_node()?;
         let span = node.as_span();
 
-        match node {
+        let res = match node {
             Node::String(pair) => {
                 let mut chars = pair.as_str().chars();
 
@@ -130,8 +132,9 @@ impl<'de> Deserializer<'de> {
                 }
             }
             _ => Err(Error::expected("string")),
-        }
-        .map_err(|e| e.with_span(span))
+        };
+
+        res.map_err(|err| err.with_span(span))
     }
 
     fn interpolate_expression(&mut self) -> Result<String> {
@@ -372,12 +375,13 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         let node = self.take_node()?;
         let span = node.as_span();
 
-        match node {
+        let res = match node {
             Node::String(pair) => visitor.visit_enum(pair.as_str().into_deserializer()),
             Node::Map(map) => visitor.visit_enum(Enum::new(map)),
             _ => Err(Error::expected("enum")),
-        }
-        .map_err(|e| e.with_span(span))
+        };
+
+        res.map_err(|err| err.with_span(span))
     }
 
     fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value>


### PR DESCRIPTION
This ensures that any `std::io::Error` emitted by third-party crates is correctly converted to `Error::Io`. Also replaces the error variants for the serde-specific errors with a single error variant `Error::Serde`.

Fixes detection of broken pipes in `main.rs`.