### PR TITLE
feat(dts): add output coloring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,27 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ansi_colours"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60e2fb6138a49ad9f1cb3c6d8f8ccbdd5e62b4dab317c1b435a47ecd7da1d28f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -22,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.45"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
+checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
 
 [[package]]
 name = "assert_cmd"
@@ -64,6 +79,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bat"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a069bad29696ecaa51ac79d3eb87abe3b65c7808ab2b3836afd9bd6c4009362"
+dependencies = [
+ "ansi_colours",
+ "ansi_term",
+ "bugreport",
+ "clircle",
+ "console",
+ "content_inspector",
+ "encoding",
+ "error-chain",
+ "globset",
+ "grep-cli",
+ "path_abs",
+ "semver 0.11.0",
+ "serde",
+ "serde_yaml",
+ "syntect",
+ "unicode-width",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +148,17 @@ dependencies = [
  "memchr",
  "regex-automata",
  "serde",
+]
+
+[[package]]
+name = "bugreport"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0014b4b2b4f63bfe69c3838470121290cc437fdc79785d408a761a21e8b2404c"
+dependencies = [
+ "git-version",
+ "shell-escape",
+ "sys-info",
 ]
 
 [[package]]
@@ -149,9 +208,9 @@ checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "bitflags",
  "textwrap 0.11.0",
@@ -198,6 +257,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "clircle"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e68bbd985a63de680ab4d1ad77b6306611a8f961b282c8b5ab513e6de934e396"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "serde",
+ "winapi",
+]
+
+[[package]]
+name = "console"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "regex",
+ "terminal_size",
+ "unicode-width",
+ "winapi",
+]
+
+[[package]]
+name = "content_inspector"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,7 +309,7 @@ checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
- "clap 2.33.3",
+ "clap 2.34.0",
  "criterion-plot",
  "csv",
  "itertools",
@@ -285,7 +389,7 @@ checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -337,18 +441,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
-name = "dtoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
-
-[[package]]
 name = "dts"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
  "atty",
+ "bat",
  "clap 3.0.0-rc.7",
  "clap_generate",
  "criterion",
@@ -397,10 +496,101 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+dependencies = [
+ "encoding-index-japanese",
+ "encoding-index-korean",
+ "encoding-index-simpchinese",
+ "encoding-index-singlebyte",
+ "encoding-index-tradchinese",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+
+[[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "flate2"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+dependencies = [
+ "cfg-if",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "float-cmp"
@@ -410,6 +600,12 @@ checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -431,10 +627,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-version"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b0decc02f4636b9ccad390dcbe77b722a77efedfa393caf8379a51d5c61899"
+dependencies = [
+ "git-version-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe69f1cbdb6e28af2bac214e943b99ce8a0a06b447d15d3e61161b0423139f3f"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "globset"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10463d9ff00a2a068db14231982f5132edebad0d7660cd956a1c30292dbcbfbd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "grep-cli"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd110c34bb4460d0de5062413b773e385cbf8a85a63fc535590110a09e79e8a"
+dependencies = [
+ "atty",
+ "bstr",
+ "globset",
+ "lazy_static",
+ "log",
+ "regex",
+ "same-file",
+ "termcolor",
+ "winapi-util",
+]
 
 [[package]]
 name = "half"
@@ -503,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
@@ -515,6 +763,12 @@ name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
@@ -538,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "jsonpath-rust"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1827b425e1ad936c0321d06d6922c2cb55cb0230f5dc04493cae2c1763c72c7f"
+checksum = "da86e332e6de16fa0e12388aeac5a295c522f9930c103cef43b2d17ccf0ba147"
 dependencies = [
  "pest",
  "pest_derive",
@@ -555,10 +809,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "libc"
-version = "0.2.106"
+name = "lazycell"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "libc"
+version = "0.2.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+
+[[package]]
+name = "line-wrap"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
+dependencies = [
+ "safemem",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -595,10 +864,20 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
  "autocfg",
 ]
 
@@ -619,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -629,9 +908,31 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+
+[[package]]
+name = "onig"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ddfe2c93bb389eea6e6d713306880c7f6dcc99a75b659ce145d962c861b225"
+dependencies = [
+ "bitflags",
+ "lazy_static",
+ "libc",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd3eee045c84695b53b20255bb7317063df090b68e18bfac0abb6c39cf7f33e"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "oorandom"
@@ -661,6 +962,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "path_abs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ef02f6342ac01d8a93b65f96db53fe68a92a15f41144f97fb00a9e669633c3"
+dependencies = [
+ "std_prelude",
 ]
 
 [[package]]
@@ -719,6 +1029,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+
+[[package]]
+name = "plist"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd39bc6cdc9355ad1dc5eeedefee696bb35c34caf21768741e81826c0bbd7225"
+dependencies = [
+ "base64",
+ "indexmap",
+ "line-wrap",
+ "serde",
+ "time",
+ "xml-rs",
+]
+
+[[package]]
 name = "plotters"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "2.0.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6ce811d0b2e103743eec01db1c50612221f173084ce2f7941053e94b6bb474"
+checksum = "95e5a7689e456ab905c22c2b48225bb921aba7c8dfa58440d68ba13f6222a715"
 dependencies = [
  "difflib",
  "float-cmp",
@@ -813,10 +1143,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.32"
+name = "proc-macro-hack"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
 dependencies = [
  "unicode-xid",
 ]
@@ -899,14 +1235,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.4",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.20.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b5ac6078ca424dc1d3ae2328526a76787fecc7f8011f520e3276730e711fc95"
+checksum = "d37e5e2290f3e040b594b1a9e04377c2c671f1a1cfd9bfdef82106ac1c113f84"
 dependencies = [
  "log",
  "ring",
@@ -916,9 +1252,15 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "same-file"
@@ -947,15 +1289,33 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
-name = "serde"
-version = "1.0.130"
+name = "semver-parser"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.132"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
 dependencies = [
  "serde_derive",
 ]
@@ -984,9 +1344,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -995,12 +1355,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
 dependencies = [
  "indexmap",
- "itoa",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
@@ -1018,12 +1378,12 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c608a35705a5d3cdc9fbe403147647ff34b921f8e833e49306df898f9b20af"
+checksum = "a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0"
 dependencies = [
- "dtoa",
  "indexmap",
+ "ryu",
  "serde",
  "yaml-rust",
 ]
@@ -1041,10 +1401,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-escape"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "std_prelude"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8207e78455ffdf55661170876f88daf85356e4edd54e0a3dbc79586ca1e50cbe"
 
 [[package]]
 name = "strsim"
@@ -1054,13 +1426,45 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.81"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
+checksum = "23a1dfb999630e338648c83e91c59a4e9fb7620f520c3194b6b89e276f2f1959"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "syntect"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b20815bbe80ee0be06e6957450a841185fcf690fe0178f14d77a05ce2caa031"
+dependencies = [
+ "bincode",
+ "bitflags",
+ "flate2",
+ "fnv",
+ "lazy_static",
+ "lazycell",
+ "onig",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
+name = "sys-info"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -1070,6 +1474,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1111,6 +1525,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
+dependencies = [
+ "itoa 0.4.8",
+ "libc",
 ]
 
 [[package]]
@@ -1206,12 +1630,13 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c448dcb78ec38c7d59ec61f87f70a98ea19171e06c139357e012ee226fec90"
+checksum = "9399fa2f927a3d327187cbd201480cee55bee6ac5d3c77dd27f0c6814cff16d5"
 dependencies = [
  "base64",
  "chunked_transfer",
+ "flate2",
  "log",
  "once_cell",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 [features]
 default = ["color"]
-color = ["bat"]
+color = ["bat", "clap/color"]
 
 [dependencies]
 anyhow = "1.0.44"
@@ -29,7 +29,8 @@ features = ["regex-onig"]
 version = "0.18.3"
 
 [dependencies.clap]
-features = ["derive", "env"]
+default-features = false
+features = ["std", "derive", "env", "suggestions"]
 version = "= 3.0.0-rc.7"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ members = [
     "crates/hcl",
 ]
 
+[features]
+default = ["color"]
+color = ["bat"]
+
 [dependencies]
 anyhow = "1.0.44"
 atty = "0.2.14"
@@ -18,8 +22,14 @@ rayon = "1.5.1"
 regex = "1.5.4"
 unescape = "0.1.0"
 
+[dependencies.bat]
+optional = true
+default-features = false
+features = ["regex-onig"]
+version = "0.18.3"
+
 [dependencies.clap]
-features = ["derive"]
+features = ["derive", "env"]
 version = "= 3.0.0-rc.7"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -63,6 +63,23 @@ Read data from stdin:
 echo '{"foo": {"bar": "baz"}}' | dts -i json -tF,r -o yaml
 ```
 
+## Output colors and themes
+
+`dts` supports output coloring and syntax highlighting. The coloring behaviour
+can be controlled via the `--color` flag or `DTS_COLOR` environment variable.
+
+If the default theme used for syntax highlighting does not suit you, you can
+change it via the `--theme` flag or `DTS_THEME` environment variable.
+
+Available themes can be listed via:
+
+```sh
+dts --list-themes
+```
+
+**Hint**: The `color` feature can be disabled at compile time if you don't want
+to have colors at all. See the [Cargo feature](#cargo-features) section below.
+
 ## Supported Encodings
 
 Right now `dts` supports the following encodings:

--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ Right now `dts` supports the following encodings:
 - Gron
 - HCL _(deserialize only)_
 
+## Cargo features
+
+Support for colored output is provided by the `color` feature which is enabled
+by default. The feature increases binary size and may be disabled via:
+
+```sh
+cargo build --no-default-features --release
+```
+
+If you just want to disable colors by default with the option to enable them
+conditionally, you can also set the [`NO_COLOR`](https://no-color.org/)
+environment variable or set `DTS_COLOR=never`.
+
 ## License
 
 The source code of dts is released under the MIT License. See the bundled

--- a/crates/dts-core/Cargo.toml
+++ b/crates/dts-core/Cargo.toml
@@ -23,7 +23,8 @@ pest_derive = "2.1.0"
 rayon = "1.5.1"
 
 [dependencies.clap]
-features = ["derive"]
+default-features = false
+features = ["std", "derive"]
 version = "= 3.0.0-rc.7"
 
 [dependencies.indexmap]

--- a/crates/dts-core/src/sink.rs
+++ b/crates/dts-core/src/sink.rs
@@ -1,7 +1,5 @@
 use crate::{Encoding, PathExt, Result};
 use std::fmt;
-use std::fs;
-use std::io;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -22,20 +20,6 @@ impl Sink {
             Self::Stdout => None,
             Self::Path(path) => Encoding::from_path(path),
         }
-    }
-
-    /// Returns a writer to write to the sink.
-    ///
-    /// ## Errors
-    ///
-    /// May return an error if the sink is `Sink::File` and the file cannot be created.
-    pub fn to_writer(&self) -> Result<impl io::Write> {
-        let writer: Box<dyn io::Write> = match self {
-            Self::Stdout => Box::new(io::stdout()),
-            Self::Path(path) => Box::new(fs::File::create(path)?),
-        };
-
-        Ok(writer)
     }
 }
 

--- a/crates/dts/args.rs
+++ b/crates/dts/args.rs
@@ -8,6 +8,9 @@ use dts_core::{transform::Transformation, Encoding, Sink, Source};
 use regex::Regex;
 use unescape::unescape;
 
+#[cfg(feature = "color")]
+use crate::color::ColorChoice;
+
 /// Simple tool to transcode between different encodings.
 ///
 /// The tool first deserializes data from the input data into an internal representation which
@@ -247,6 +250,29 @@ pub struct OutputOptions {
     /// extension (or the output is stdout), the fallback is to encode output as JSON.
     #[clap(arg_enum, short = 'o', long, setting = ArgSettings::HidePossibleValues)]
     pub output_encoding: Option<Encoding>,
+
+    /// Controls when to use colors.
+    ///
+    /// The default setting is `auto`, which means dts will try to guess when to use colors. For
+    /// example, if dts is printing to a terminal, then it will use colors, but if it is redirected
+    /// to a file or a pipe, then it will suppress color output. Output is also not colored if the
+    /// TERM environment variable isn't set or the terminal is `dumb`.
+    #[cfg(feature = "color")]
+    #[clap(arg_enum, long, name = "WHEN")]
+    #[clap(default_value = "auto", env = "DTS_COLOR")]
+    pub color: ColorChoice,
+
+    /// Controls the color theme to use.
+    ///
+    /// See --list-themes for available color themes.
+    #[cfg(feature = "color")]
+    #[clap(long, env = "DTS_THEME")]
+    pub theme: Option<String>,
+
+    /// List available color themes and exit.
+    #[cfg(feature = "color")]
+    #[clap(long)]
+    pub list_themes: bool,
 
     /// Emit output data in a compact format.
     ///

--- a/crates/dts/args.rs
+++ b/crates/dts/args.rs
@@ -256,7 +256,10 @@ pub struct OutputOptions {
     /// The default setting is `auto`, which means dts will try to guess when to use colors. For
     /// example, if dts is printing to a terminal, then it will use colors, but if it is redirected
     /// to a file or a pipe, then it will suppress color output. Output is also not colored if the
-    /// TERM environment variable isn't set or the terminal is `dumb`.
+    /// TERM environment variable isn't set or the terminal is `dumb` or if the buffer to be colored
+    /// is larger than 1MB.
+    ///
+    /// Use color `always` to enforce coloring.
     #[cfg(feature = "color")]
     #[clap(arg_enum, long, name = "WHEN")]
     #[clap(default_value = "auto", env = "DTS_COLOR")]

--- a/crates/dts/args.rs
+++ b/crates/dts/args.rs
@@ -41,7 +41,7 @@ pub struct Options {
     /// there are more elements than files.
     ///
     /// Passing '-' as filename or providing no output files will write the data to stdout instead.
-    #[clap(short = 'O', long = "sink", name = "SINK", value_hint = ValueHint::FilePath)]
+    #[clap(short = 'O', long = "sink", value_name = "SINK", value_hint = ValueHint::FilePath)]
     #[clap(multiple_occurrences = true)]
     pub sinks: Vec<Sink>,
 
@@ -59,7 +59,7 @@ pub struct Options {
     pub output: OutputOptions,
 
     /// If provided, outputs the completion file for the given shell.
-    #[clap(long, name = "SHELL", arg_enum)]
+    #[clap(arg_enum, long, value_name = "SHELL")]
     pub generate_completion: Option<Shell>,
 }
 
@@ -261,7 +261,7 @@ pub struct OutputOptions {
     ///
     /// Use color `always` to enforce coloring.
     #[cfg(feature = "color")]
-    #[clap(arg_enum, long, name = "WHEN")]
+    #[clap(arg_enum, long, value_name = "WHEN")]
     #[clap(default_value = "auto", env = "DTS_COLOR")]
     pub color: ColorChoice,
 
@@ -274,7 +274,7 @@ pub struct OutputOptions {
 
     /// List available color themes and exit.
     #[cfg(feature = "color")]
-    #[clap(long)]
+    #[clap(long, conflicts_with = "generate-completion")]
     pub list_themes: bool,
 
     /// Emit output data in a compact format.

--- a/crates/dts/color.rs
+++ b/crates/dts/color.rs
@@ -95,7 +95,6 @@ impl<'a> StdoutWriter<'a> {
     // default.
     fn theme(&self, printer: &PrettyPrinter) -> &str {
         self.theme
-            .as_deref()
             .and_then(|requested| {
                 printer
                     .themes()

--- a/crates/dts/color.rs
+++ b/crates/dts/color.rs
@@ -120,17 +120,17 @@ impl<'a> StdoutWriter<'a> {
             return Ok(());
         }
 
-        if self.should_colorize(&buf) {
+        if self.should_colorize(buf) {
             let mut printer = PrettyPrinter::new();
             let theme = self.theme(&printer);
-            let input = Input::from_bytes(&buf).name(self.pseudo_filename());
+            let input = Input::from_bytes(buf).name(self.pseudo_filename());
 
             match printer.input(input).theme(theme).print() {
                 Ok(_) => Ok(()),
                 Err(err) => Err(io::Error::new(io::ErrorKind::Other, err.to_string())),
             }
         } else {
-            io::stdout().write_all(&buf)
+            io::stdout().write_all(buf)
         }
     }
 }

--- a/crates/dts/color.rs
+++ b/crates/dts/color.rs
@@ -122,17 +122,17 @@ impl<'a> StdoutWriter<'a> {
             return Ok(());
         }
 
-        if self.should_colorize(buf) {
-            let mut printer = PrettyPrinter::new();
-            let theme = self.theme(&printer);
-            let input = Input::from_bytes(buf).name(self.pseudo_filename());
+        if !self.should_colorize(buf) {
+            return io::stdout().write_all(buf);
+        }
 
-            match printer.input(input).theme(theme).print() {
-                Ok(_) => Ok(()),
-                Err(err) => Err(io::Error::new(io::ErrorKind::Other, err.to_string())),
-            }
-        } else {
-            io::stdout().write_all(buf)
+        let mut printer = PrettyPrinter::new();
+        let theme = self.theme(&printer);
+        let input = Input::from_bytes(buf).name(self.pseudo_filename());
+
+        match printer.input(input).theme(theme).print() {
+            Ok(_) => Ok(()),
+            Err(err) => Err(io::Error::new(io::ErrorKind::Other, err.to_string())),
         }
     }
 }

--- a/crates/dts/color.rs
+++ b/crates/dts/color.rs
@@ -1,11 +1,11 @@
-use anyhow::{anyhow, Result};
 use bat::{assets::HighlightingAssets, Input, PrettyPrinter};
 use clap::ArgEnum;
 use dts_core::Encoding;
-use std::{env, fmt, path::Path};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 
 /// ColorChoice represents the color preference of a user.
-#[derive(ArgEnum, Debug, PartialEq, Clone)]
+#[derive(ArgEnum, Debug, PartialEq, Clone, Copy)]
 pub enum ColorChoice {
     /// Always color output even if stdout is a file.
     Always,
@@ -14,7 +14,6 @@ pub enum ColorChoice {
     /// environment variable.
     Auto,
     /// Never color output.
-    #[clap(alias = "off")]
     Never,
 }
 
@@ -30,7 +29,7 @@ impl ColorChoice {
 
     #[cfg(not(windows))]
     fn env_allows_color(&self) -> bool {
-        match env::var_os("TERM") {
+        match std::env::var_os("TERM") {
             None => return false,
             Some(k) => {
                 if k == "dumb" {
@@ -39,7 +38,7 @@ impl ColorChoice {
             }
         }
 
-        env::var_os("NO_COLOR").is_none()
+        std::env::var_os("NO_COLOR").is_none()
     }
 
     #[cfg(windows)]
@@ -47,23 +46,13 @@ impl ColorChoice {
         // On Windows, if TERM isn't set, then we shouldn't automatically
         // assume that colors aren't allowed. This is unlike Unix environments
         // where TERM is more rigorously set.
-        if let Some(k) = env::var_os("TERM") {
+        if let Some(k) = std::env::var_os("TERM") {
             if k == "dumb" {
                 return false;
             }
         }
 
-        env::var_os("NO_COLOR").is_none()
-    }
-}
-
-impl fmt::Display for ColorChoice {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ColorChoice::Always => f.write_str("always"),
-            ColorChoice::Auto => f.write_str("auto"),
-            ColorChoice::Never => f.write_str("never"),
-        }
+        std::env::var_os("NO_COLOR").is_none()
     }
 }
 
@@ -75,30 +64,95 @@ pub fn themes() -> Vec<String> {
         .collect()
 }
 
-/// Applies syntax highlighting to the contents of `buf` based on the `Encoding` and theme and
-/// prints the result to stdout.
-pub fn print_highlighted(buf: &[u8], encoding: Encoding, theme: Option<&str>) -> Result<()> {
+/// StdoutWriter writes data to stdout and may or may not colorize it.
+pub struct StdoutWriter<'a> {
+    color_choice: ColorChoice,
+    encoding: Encoding,
+    theme: Option<&'a str>,
+    buf: Option<Vec<u8>>,
+}
+
+impl<'a> StdoutWriter<'a> {
+    /// Creates a new `StdoutWriter` which may colorize output using the provided theme and
+    /// `Encoding` hint based on the `ColorChoice`.
+    pub fn new(color_choice: ColorChoice, encoding: Encoding, theme: Option<&'a str>) -> Self {
+        StdoutWriter {
+            color_choice,
+            encoding,
+            theme,
+            buf: Some(Vec::with_capacity(256)),
+        }
+    }
+
     // The pseudo filename will determine the syntax highlighting used by the PrettyPrinter.
-    let filename = Path::new("out").with_extension(encoding.as_str());
-    let input = Input::from_bytes(buf).name(filename);
+    fn pseudo_filename(&self) -> PathBuf {
+        Path::new("out").with_extension(self.encoding.as_str())
+    }
 
-    let mut printer = PrettyPrinter::new();
-
-    // Check if the printer knows the requested theme, otherwise fall back to the `base16` as
+    // Checks if the `PrettyPrinter` knows the requested theme, otherwise fall back to `base16` as
     // default.
-    let theme = theme
-        .and_then(|requested| {
-            printer
-                .themes()
-                .find(|known| known == &requested)
-                .and(Some(requested))
-        })
-        .unwrap_or("base16");
+    fn theme(&self, printer: &PrettyPrinter) -> &str {
+        self.theme
+            .as_deref()
+            .and_then(|requested| {
+                printer
+                    .themes()
+                    .find(|known| known == &requested)
+                    .and(Some(requested))
+            })
+            .unwrap_or("base16")
+    }
 
-    printer
-        .input(input)
-        .theme(theme)
-        .print()
-        .map(|_| ())
-        .map_err(|err| anyhow!("{}", err))
+    fn should_colorize(&self, buf: &[u8]) -> bool {
+        match self.color_choice {
+            ColorChoice::Always => true,
+            ColorChoice::Never => false,
+            ColorChoice::Auto => {
+                // Only highlight if the buffer is <= 1MB by default.
+                // Syntax highlighting of multiple thousand lines is slow.
+                self.color_choice.should_colorize() && buf.len() <= 1_048_576
+            }
+        }
+    }
+
+    fn flush_buf(&self, buf: &[u8]) -> io::Result<()> {
+        if buf.is_empty() {
+            return Ok(());
+        }
+
+        if self.should_colorize(&buf) {
+            let mut printer = PrettyPrinter::new();
+            let theme = self.theme(&printer);
+            let input = Input::from_bytes(&buf).name(self.pseudo_filename());
+
+            match printer.input(input).theme(theme).print() {
+                Ok(_) => Ok(()),
+                Err(err) => Err(io::Error::new(io::ErrorKind::Other, err.to_string())),
+            }
+        } else {
+            io::stdout().write_all(&buf)
+        }
+    }
+}
+
+impl<'a> io::Write for StdoutWriter<'a> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self.buf.as_mut() {
+            Some(w) => w.write(buf),
+            None => panic!("StdoutWriter was already flushed"),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self.buf.take() {
+            Some(buf) => self.flush_buf(&buf),
+            None => Ok(()),
+        }
+    }
+}
+
+impl<'a> Drop for StdoutWriter<'a> {
+    fn drop(&mut self) {
+        let _ = self.flush();
+    }
 }

--- a/crates/dts/color.rs
+++ b/crates/dts/color.rs
@@ -1,3 +1,5 @@
+//! Utilities to facilitate colorful output.
+
 use bat::{assets::HighlightingAssets, Input, PrettyPrinter};
 use clap::ArgEnum;
 use dts_core::Encoding;

--- a/crates/dts/color.rs
+++ b/crates/dts/color.rs
@@ -1,0 +1,69 @@
+use clap::ArgEnum;
+use std::env;
+use std::fmt;
+
+// Re-exports
+pub use bat::{assets::HighlightingAssets, Input, PrettyPrinter};
+
+/// ColorChoice represents the color preference of a user.
+#[derive(ArgEnum, Debug, PartialEq, Clone)]
+pub enum ColorChoice {
+    /// Always color output even if stdout is a file.
+    Always,
+    /// Automatically detect if output should be colored. Coloring is disabled if stdout is not
+    /// interactive or a dumb term, or the user explicitly disabled colors via `NO_COLOR`
+    /// environment variable.
+    Auto,
+    /// Never color output.
+    #[clap(alias = "off")]
+    Never,
+}
+
+impl ColorChoice {
+    /// Returns true if the `ColorChoice` indicates that coloring is enabled.
+    pub fn should_colorize(&self) -> bool {
+        match *self {
+            ColorChoice::Always => true,
+            ColorChoice::Never => false,
+            ColorChoice::Auto => self.env_allows_color() && atty::is(atty::Stream::Stdout),
+        }
+    }
+
+    #[cfg(not(windows))]
+    fn env_allows_color(&self) -> bool {
+        match env::var_os("TERM") {
+            None => return false,
+            Some(k) => {
+                if k == "dumb" {
+                    return false;
+                }
+            }
+        }
+
+        env::var_os("NO_COLOR").is_none()
+    }
+
+    #[cfg(windows)]
+    fn env_allows_color(&self) -> bool {
+        // On Windows, if TERM isn't set, then we shouldn't automatically
+        // assume that colors aren't allowed. This is unlike Unix environments
+        // where TERM is more rigorously set.
+        if let Some(k) = env::var_os("TERM") {
+            if k == "dumb" {
+                return false;
+            }
+        }
+
+        env::var_os("NO_COLOR").is_none()
+    }
+}
+
+impl fmt::Display for ColorChoice {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ColorChoice::Always => f.write_str("always"),
+            ColorChoice::Auto => f.write_str("auto"),
+            ColorChoice::Never => f.write_str("never"),
+        }
+    }
+}

--- a/crates/dts/main.rs
+++ b/crates/dts/main.rs
@@ -11,12 +11,10 @@ use clap_generate::{generate, Shell};
 use dts_core::{de::Deserializer, ser::Serializer};
 use dts_core::{transform, Encoding, Error, Sink, Source, Value};
 use rayon::prelude::*;
-use std::io::{self, BufReader, BufWriter};
+use std::io::{self, BufReader, BufWriter, Write};
 
 #[cfg(feature = "color")]
 mod color;
-#[cfg(feature = "color")]
-use std::path::Path;
 
 fn deserialize(source: &Source, opts: &InputOptions) -> Result<Value> {
     let encoding = opts
@@ -69,6 +67,60 @@ fn transform(value: Value, opts: &TransformOptions) -> Result<Value> {
     transform::apply_chain(&opts.transform, value).context("Failed to transform value")
 }
 
+fn serialize(sink: &Sink, value: &Value, opts: &OutputOptions) -> Result<()> {
+    let encoding = opts
+        .output_encoding
+        .or_else(|| sink.encoding())
+        .unwrap_or(Encoding::Json);
+
+    serialize_impl(sink, encoding, value, opts)
+        .with_context(|| format!("Failed to serialize `{}` to `{}`", encoding, sink))
+}
+
+#[cfg(feature = "color")]
+fn serialize_impl(
+    sink: &Sink,
+    encoding: Encoding,
+    value: &Value,
+    opts: &OutputOptions,
+) -> Result<()> {
+    let mut writer = sink
+        .to_writer()
+        .with_context(|| format!("Failed to create writer for sink `{}`", sink))?;
+
+    if sink == &Sink::Stdout && opts.color.should_colorize() {
+        // Slow colorful path.
+        let mut buf = Vec::with_capacity(256);
+
+        serialize_writer(&mut buf, encoding, value, opts)?;
+
+        // Only highlight if the buffer is <= 1MB or the user specified to always use colors.
+        // Syntax highlighting of multiple thousand lines is slow.
+        if opts.color == color::ColorChoice::Always || buf.len() <= 1_048_576 {
+            color::print_highlighted(&buf, encoding, opts.theme.as_deref())
+        } else {
+            Ok(writer.write_all(&buf)?)
+        }
+    } else {
+        // Fast path.
+        serialize_writer(writer, encoding, value, opts)
+    }
+}
+
+#[cfg(not(feature = "color"))]
+fn serialize_impl(
+    sink: &Sink,
+    encoding: Encoding,
+    value: &Value,
+    opts: &OutputOptions,
+) -> Result<()> {
+    let writer = sink
+        .to_writer()
+        .with_context(|| format!("Failed to create writer for sink `{}`", sink))?;
+
+    serialize_writer(writer, encoding, value, opts)
+}
+
 fn serialize_writer<W>(
     writer: W,
     encoding: Encoding,
@@ -85,63 +137,6 @@ where
         Err(Error::Io(err)) if err.kind() == io::ErrorKind::BrokenPipe => Ok(()),
         Err(err) => Err(err.into()),
     }
-}
-
-#[cfg(feature = "color")]
-fn serialize_colored(encoding: Encoding, value: &Value, opts: &OutputOptions) -> Result<()> {
-    let mut buf = Vec::with_capacity(256);
-
-    serialize_writer(&mut buf, encoding, value, opts)?;
-
-    // Pseudo filename which will determine the syntax highlighting used by the PrettyPrinter.
-    let filename = Path::new("out").with_extension(encoding.as_str());
-
-    // The PrettyPrinter will always write to io::Stdout.
-    let mut printer = color::PrettyPrinter::new();
-
-    printer
-        .input(color::Input::from_bytes(&buf).name(filename))
-        .theme(opts.theme.as_deref().unwrap_or("base16"))
-        .print()
-        .map(|_| ())
-        .map_err(|err| anyhow!("{}", err))
-}
-
-#[cfg(feature = "color")]
-fn serialize(sink: &Sink, value: &Value, opts: &OutputOptions) -> Result<()> {
-    let encoding = opts
-        .output_encoding
-        .or_else(|| sink.encoding())
-        .unwrap_or(Encoding::Json);
-
-    let res = if sink == &Sink::Stdout && opts.color.should_colorize() {
-        // Slow colorful path.
-        serialize_colored(encoding, value, opts)
-    } else {
-        // Fast path.
-        let writer = sink
-            .to_writer()
-            .with_context(|| format!("Failed to create writer for sink `{}`", sink))?;
-
-        serialize_writer(writer, encoding, value, opts)
-    };
-
-    res.with_context(|| format!("Failed to serialize `{}` to `{}`", encoding, sink))
-}
-
-#[cfg(not(feature = "color"))]
-fn serialize(sink: &Sink, value: &Value, opts: &OutputOptions) -> Result<()> {
-    let encoding = opts
-        .output_encoding
-        .or_else(|| sink.encoding())
-        .unwrap_or(Encoding::Json);
-
-    let writer = sink
-        .to_writer()
-        .with_context(|| format!("Failed to create writer for sink `{}`", sink))?;
-
-    serialize_writer(writer, encoding, value, opts)
-        .with_context(|| format!("Failed to serialize `{}` to `{}`", encoding, sink))
 }
 
 fn serialize_many(sinks: &[Sink], value: &mut Value, opts: &OutputOptions) -> Result<()> {
@@ -191,8 +186,9 @@ fn main() -> Result<()> {
 
     #[cfg(feature = "color")]
     if opts.output.list_themes {
-        let assets = color::HighlightingAssets::from_binary();
-        assets.themes().for_each(|theme| println!("{}", theme));
+        for theme in color::themes() {
+            println!("{}", theme)
+        }
         std::process::exit(0);
     }
 


### PR DESCRIPTION
The coloring is built on top of [`bat`](https://github.com/sharkdp/bat) which is used as a library for its coloring capabilities.

Since the color support is quite heavy on dependencies it's gated behind a feature flag so that it can be disabled at compile time if desired.

Changes:

- add `--color` flag to control the coloring behaviour
- add `--theme` flag to change the color theme
- add `--list-themes` to list all available color themes
- automatically color output based on the output encoding

Closes #5.