### PR TITLE
refactor(dts): make `HighlightingAssets` cacheable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,6 +454,7 @@ dependencies = [
  "criterion",
  "dts-core",
  "hcl",
+ "once_cell",
  "predicates",
  "pretty_assertions",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 [features]
 default = ["color"]
-color = ["bat", "bat/paging", "clap/color"]
+color = ["bat", "bat/paging", "clap/color", "once_cell"]
 
 [dependencies]
 anyhow = "1.0.44"
@@ -33,6 +33,10 @@ version = "0.18.3"
 default-features = false
 features = ["std", "derive", "env", "suggestions"]
 version = "= 3.0.0-rc.7"
+
+[dependencies.once_cell]
+optional = true
+version = "1.9.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.2"

--- a/crates/dts/main.rs
+++ b/crates/dts/main.rs
@@ -12,7 +12,7 @@ use args::{InputOptions, Options, OutputOptions, TransformOptions};
 use clap::{App, IntoApp, Parser};
 use clap_generate::{generate, Shell};
 #[cfg(feature = "color")]
-use color::ColoredStdoutWriter;
+use color::{ColoredStdoutWriter, HighlightingConfig};
 use dts_core::{de::Deserializer, ser::Serializer};
 use dts_core::{transform, Encoding, Error, Sink, Source, Value};
 use no_color::StdoutWriter;
@@ -84,11 +84,8 @@ fn serialize(sink: &Sink, value: &Value, opts: &OutputOptions) -> Result<()> {
         #[cfg(feature = "color")]
         Sink::Stdout => {
             if opts.color.should_colorize() {
-                Box::new(ColoredStdoutWriter::new(
-                    encoding,
-                    opts.theme.as_deref(),
-                    paging_config,
-                ))
+                let config = HighlightingConfig::new(paging_config, opts.theme.as_deref());
+                Box::new(ColoredStdoutWriter::new(encoding, config))
             } else {
                 Box::new(StdoutWriter::new(paging_config))
             }
@@ -158,7 +155,7 @@ fn main() -> Result<()> {
 
     #[cfg(feature = "color")]
     if opts.output.list_themes {
-        for theme in color::themes() {
+        for theme in color::highlighting_assets().themes() {
             println!("{}", theme)
         }
         std::process::exit(0);


### PR DESCRIPTION
This is a relatively big refactor which replaces the usage of
`bat::PrettyPrinter` with a wrapper around `bat::controller::Controller`
to have better control of loading the highlighting assets as this is a
very heavy operations and we only ever want to do it once during the
whole runtime of `dts`.

This will enable some performance improvements later. Along the way I
added some defaulting here and there and made theme selection
case-insensitive for convenience.