### PR TITLE
feat: add custom `Value` impl behind feature switch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,7 +460,6 @@ dependencies = [
  "pretty_assertions",
  "rayon",
  "regex",
- "serde_json",
  "shell-words",
  "temp-env",
  "termcolor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
 [features]
 default = ["color"]
 color = ["bat", "bat/paging", "clap/color", "once_cell", "termcolor"]
+custom_value = ["dts-core/custom_value"]
 
 [dependencies]
 anyhow = "1.0.44"
@@ -50,10 +51,6 @@ hcl = { path = "crates/hcl" }
 pretty_assertions = "1.0.0"
 predicates = "2.0.3"
 temp-env = "0.2.0"
-
-[dev-dependencies.serde_json]
-features = ["preserve_order"]
-version = "1.0.68"
 
 [[bench]]
 name = "benchmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [features]
-default = ["color"]
+default = ["color", "custom_value"]
 color = ["bat", "bat/paging", "clap/color", "once_cell", "termcolor"]
 custom_value = ["dts-core/custom_value"]
 

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,6 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use dts_core::transform::*;
-use serde_json::json;
+use dts_core::{json, transform::*};
 
 fn benchmark_transform(c: &mut Criterion) {
     c.bench_function("expand_keys", |b| {

--- a/crates/dts-core/Cargo.toml
+++ b/crates/dts-core/Cargo.toml
@@ -3,6 +3,9 @@ name = "dts-core"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+custom_value = []
+
 [dependencies]
 csv = "1.1.6"
 glob = "0.3.0"

--- a/crates/dts-core/src/de.rs
+++ b/crates/dts-core/src/de.rs
@@ -2,10 +2,9 @@
 //! encodings into a `Value`.
 
 use crate::parsers::gron;
-use crate::{Encoding, Result, Value, ValueExt};
+use crate::{to_value, Encoding, Map, Result, Value, ValueExt};
 use regex::Regex;
 use serde::Deserialize;
-use serde_json::Map;
 
 /// Options for the `Deserializer`. The options are context specific and may only be honored when
 /// deserializing from a certain `Encoding`.
@@ -118,7 +117,7 @@ where
     ///
     /// ```
     /// use dts_core::{de::DeserializerBuilder, Encoding};
-    /// use serde_json::json;
+    /// use dts_core::json;
     /// # use std::error::Error;
     /// #
     /// # fn main() -> Result<(), Box<dyn Error>> {
@@ -206,10 +205,7 @@ where
                 None => Value::Array(Vec::new()),
             }
         } else {
-            Value::Array(
-                iter.map(|v| Ok(serde_json::to_value(v?)?))
-                    .collect::<Result<_>>()?,
-            )
+            Value::Array(iter.map(|v| Ok(to_value(v?)?)).collect::<Result<_>>()?)
         };
 
         Ok(value)
@@ -238,7 +234,7 @@ where
             pattern
                 .split(&s)
                 .filter(|m| !m.is_empty())
-                .map(|m| Ok(serde_json::to_value(m)?))
+                .map(|m| Ok(to_value(m)?))
                 .collect::<Result<_>>()?,
         ))
     }
@@ -268,8 +264,8 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::json;
     use pretty_assertions::assert_eq;
-    use serde_json::json;
 
     #[test]
     fn test_deserialize_yaml() {

--- a/crates/dts-core/src/lib.rs
+++ b/crates/dts-core/src/lib.rs
@@ -9,17 +9,28 @@ pub use encoding::*;
 pub use error::*;
 pub use sink::Sink;
 pub use source::Source;
-pub use value::*;
 
 pub mod de;
 mod encoding;
 mod error;
+#[cfg(feature = "custom_value")]
+mod number;
 mod parsers;
 pub mod ser;
 mod sink;
 mod source;
 pub mod transform;
+#[cfg(feature = "custom_value")]
 mod value;
+mod value_ext;
+
+#[macro_use]
+mod macros;
+
+#[cfg(not(feature = "custom_value"))]
+pub use serde_json::{to_value, Map, Number, Value};
+#[cfg(feature = "custom_value")]
+pub use value::{to_value, Map, Number, Value};
 
 trait PathExt {
     fn relative_to<P>(&self, path: P) -> Option<PathBuf>

--- a/crates/dts-core/src/macros.rs
+++ b/crates/dts-core/src/macros.rs
@@ -1,0 +1,308 @@
+/// These macros were copied mostly unchanged from [`serde_json`][serde-json-macros]. Copyright
+/// belongs to the original authors.
+///
+/// [serde-json-macros]: https://github.com/serde-rs/json/blob/9357569b1c56b12025c83f4840805bcbc678becd/src/macros.rs
+///
+/// Construct a `dts_core::Value` from a JSON literal.
+///
+/// ```
+/// # use dts_core::json;
+/// #
+/// let value = json!({
+///     "code": 200,
+///     "success": true,
+///     "payload": {
+///         "features": [
+///             "serde",
+///             "json"
+///         ]
+///     }
+/// });
+/// ```
+///
+/// Variables or expressions can be interpolated into the JSON literal. Any type
+/// interpolated into an array element or object value must implement Serde's
+/// `Serialize` trait, while any type interpolated into a object key must
+/// implement `Into<String>`. If the `Serialize` implementation of the
+/// interpolated type decides to fail, or if the interpolated type contains a
+/// map with non-string keys, the `json!` macro will panic.
+///
+/// ```
+/// # use dts_core::json;
+/// #
+/// let code = 200;
+/// let features = vec!["serde", "json"];
+///
+/// let value = json!({
+///     "code": code,
+///     "success": code == 200,
+///     "payload": {
+///         features[0]: features[1]
+///     }
+/// });
+/// ```
+///
+/// Trailing commas are allowed inside both arrays and objects.
+///
+/// ```
+/// # use dts_core::json;
+/// #
+/// let value = json!([
+///     "notice",
+///     "the",
+///     "trailing",
+///     "comma -->",
+/// ]);
+/// ```
+#[macro_export(local_inner_macros)]
+macro_rules! json {
+    // Hide distracting implementation details from the generated rustdoc.
+    ($($json:tt)+) => {
+        json_internal!($($json)+)
+    };
+}
+
+// Rocket relies on this because they export their own `json!` with a different
+// doc comment than ours, and various Rust bugs prevent them from calling our
+// `json!` from their `json!` so they call `json_internal!` directly. Check with
+// @SergioBenitez before making breaking changes to this macro.
+//
+// Changes are fine as long as `json_internal!` does not call any new helper
+// macros and can still be invoked as `json_internal!($($json)+)`.
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
+macro_rules! json_internal {
+    //////////////////////////////////////////////////////////////////////////
+    // TT muncher for parsing the inside of an array [...]. Produces a vec![...]
+    // of the elements.
+    //
+    // Must be invoked as: json_internal!(@array [] $($tt)*)
+    //////////////////////////////////////////////////////////////////////////
+
+    // Done with trailing comma.
+    (@array [$($elems:expr,)*]) => {
+        json_internal_vec![$($elems,)*]
+    };
+
+    // Done without trailing comma.
+    (@array [$($elems:expr),*]) => {
+        json_internal_vec![$($elems),*]
+    };
+
+    // Next element is `null`.
+    (@array [$($elems:expr,)*] null $($rest:tt)*) => {
+        json_internal!(@array [$($elems,)* json_internal!(null)] $($rest)*)
+    };
+
+    // Next element is `true`.
+    (@array [$($elems:expr,)*] true $($rest:tt)*) => {
+        json_internal!(@array [$($elems,)* json_internal!(true)] $($rest)*)
+    };
+
+    // Next element is `false`.
+    (@array [$($elems:expr,)*] false $($rest:tt)*) => {
+        json_internal!(@array [$($elems,)* json_internal!(false)] $($rest)*)
+    };
+
+    // Next element is an array.
+    (@array [$($elems:expr,)*] [$($array:tt)*] $($rest:tt)*) => {
+        json_internal!(@array [$($elems,)* json_internal!([$($array)*])] $($rest)*)
+    };
+
+    // Next element is a map.
+    (@array [$($elems:expr,)*] {$($map:tt)*} $($rest:tt)*) => {
+        json_internal!(@array [$($elems,)* json_internal!({$($map)*})] $($rest)*)
+    };
+
+    // Next element is an expression followed by comma.
+    (@array [$($elems:expr,)*] $next:expr, $($rest:tt)*) => {
+        json_internal!(@array [$($elems,)* json_internal!($next),] $($rest)*)
+    };
+
+    // Last element is an expression with no trailing comma.
+    (@array [$($elems:expr,)*] $last:expr) => {
+        json_internal!(@array [$($elems,)* json_internal!($last)])
+    };
+
+    // Comma after the most recent element.
+    (@array [$($elems:expr),*] , $($rest:tt)*) => {
+        json_internal!(@array [$($elems,)*] $($rest)*)
+    };
+
+    // Unexpected token after most recent element.
+    (@array [$($elems:expr),*] $unexpected:tt $($rest:tt)*) => {
+        json_unexpected!($unexpected)
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // TT muncher for parsing the inside of an object {...}. Each entry is
+    // inserted into the given map variable.
+    //
+    // Must be invoked as: json_internal!(@object $map () ($($tt)*) ($($tt)*))
+    //
+    // We require two copies of the input tokens so that we can match on one
+    // copy and trigger errors on the other copy.
+    //////////////////////////////////////////////////////////////////////////
+
+    // Done.
+    (@object $object:ident () () ()) => {};
+
+    // Insert the current entry followed by trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr) , $($rest:tt)*) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+        json_internal!(@object $object () ($($rest)*) ($($rest)*));
+    };
+
+    // Current entry followed by unexpected token.
+    (@object $object:ident [$($key:tt)+] ($value:expr) $unexpected:tt $($rest:tt)*) => {
+        json_unexpected!($unexpected);
+    };
+
+    // Insert the last entry without trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr)) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+    };
+
+    // Next value is `null`.
+    (@object $object:ident ($($key:tt)+) (: null $($rest:tt)*) $copy:tt) => {
+        json_internal!(@object $object [$($key)+] (json_internal!(null)) $($rest)*);
+    };
+
+    // Next value is `true`.
+    (@object $object:ident ($($key:tt)+) (: true $($rest:tt)*) $copy:tt) => {
+        json_internal!(@object $object [$($key)+] (json_internal!(true)) $($rest)*);
+    };
+
+    // Next value is `false`.
+    (@object $object:ident ($($key:tt)+) (: false $($rest:tt)*) $copy:tt) => {
+        json_internal!(@object $object [$($key)+] (json_internal!(false)) $($rest)*);
+    };
+
+    // Next value is an array.
+    (@object $object:ident ($($key:tt)+) (: [$($array:tt)*] $($rest:tt)*) $copy:tt) => {
+        json_internal!(@object $object [$($key)+] (json_internal!([$($array)*])) $($rest)*);
+    };
+
+    // Next value is a map.
+    (@object $object:ident ($($key:tt)+) (: {$($map:tt)*} $($rest:tt)*) $copy:tt) => {
+        json_internal!(@object $object [$($key)+] (json_internal!({$($map)*})) $($rest)*);
+    };
+
+    // Next value is an expression followed by comma.
+    (@object $object:ident ($($key:tt)+) (: $value:expr , $($rest:tt)*) $copy:tt) => {
+        json_internal!(@object $object [$($key)+] (json_internal!($value)) , $($rest)*);
+    };
+
+    // Last value is an expression with no trailing comma.
+    (@object $object:ident ($($key:tt)+) (: $value:expr) $copy:tt) => {
+        json_internal!(@object $object [$($key)+] (json_internal!($value)));
+    };
+
+    // Missing value for last entry. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)+) (:) $copy:tt) => {
+        // "unexpected end of macro invocation"
+        json_internal!();
+    };
+
+    // Missing colon and value for last entry. Trigger a reasonable error
+    // message.
+    (@object $object:ident ($($key:tt)+) () $copy:tt) => {
+        // "unexpected end of macro invocation"
+        json_internal!();
+    };
+
+    // Misplaced colon. Trigger a reasonable error message.
+    (@object $object:ident () (: $($rest:tt)*) ($colon:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `:`".
+        json_unexpected!($colon);
+    };
+
+    // Found a comma inside a key. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)*) (, $($rest:tt)*) ($comma:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `,`".
+        json_unexpected!($comma);
+    };
+
+    // Key is fully parenthesized. This avoids clippy double_parens false
+    // positives because the parenthesization may be necessary here.
+    (@object $object:ident () (($key:expr) : $($rest:tt)*) $copy:tt) => {
+        json_internal!(@object $object ($key) (: $($rest)*) (: $($rest)*));
+    };
+
+    // Refuse to absorb colon token into key expression.
+    (@object $object:ident ($($key:tt)*) (: $($unexpected:tt)+) $copy:tt) => {
+        json_expect_expr_comma!($($unexpected)+);
+    };
+
+    // Munch a token into the current key.
+    (@object $object:ident ($($key:tt)*) ($tt:tt $($rest:tt)*) $copy:tt) => {
+        json_internal!(@object $object ($($key)* $tt) ($($rest)*) ($($rest)*));
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // The main implementation.
+    //
+    // Must be invoked as: json_internal!($($json)+)
+    //////////////////////////////////////////////////////////////////////////
+
+    (null) => {
+        $crate::Value::Null
+    };
+
+    (true) => {
+        $crate::Value::Bool(true)
+    };
+
+    (false) => {
+        $crate::Value::Bool(false)
+    };
+
+    ([]) => {
+        $crate::Value::Array(json_internal_vec![])
+    };
+
+    ([ $($tt:tt)+ ]) => {
+        $crate::Value::Array(json_internal!(@array [] $($tt)+))
+    };
+
+    ({}) => {
+        $crate::Value::Object($crate::Map::new())
+    };
+
+    ({ $($tt:tt)+ }) => {
+        $crate::Value::Object({
+            let mut object = $crate::Map::new();
+            json_internal!(@object object () ($($tt)+) ($($tt)+));
+            object
+        })
+    };
+
+    // Any Serialize type: numbers, strings, struct literals, variables etc.
+    // Must be below every other rule.
+    ($other:expr) => {
+        $crate::to_value(&$other).unwrap()
+    };
+}
+
+// The json_internal macro above cannot invoke vec directly because it uses
+// local_inner_macros. A vec invocation there would resolve to $crate::vec.
+// Instead invoke vec here outside of local_inner_macros.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! json_internal_vec {
+    ($($content:tt)*) => {
+        vec![$($content)*]
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! json_unexpected {
+    () => {};
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! json_expect_expr_comma {
+    ($e:expr , $($tt:tt)*) => {};
+}

--- a/crates/dts-core/src/number.rs
+++ b/crates/dts-core/src/number.rs
@@ -1,7 +1,7 @@
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::{self, Display};
 
-/// Represents a HCL number.
+/// Represents a number.
 #[derive(Debug, PartialEq, Clone)]
 pub enum Number {
     /// Represents a positive integer.
@@ -179,7 +179,7 @@ impl<'de> Deserialize<'de> for Number {
             type Value = Number;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("a HCL number")
+                formatter.write_str("a number")
             }
 
             fn visit_i64<E>(self, value: i64) -> Result<Number, E> {

--- a/crates/dts-core/src/number.rs
+++ b/crates/dts-core/src/number.rs
@@ -1,0 +1,200 @@
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt::{self, Display};
+
+/// Represents a HCL number.
+#[derive(Debug, PartialEq, Clone)]
+pub enum Number {
+    /// Represents a positive integer.
+    PosInt(u64),
+    /// Represents a negative integer.
+    NegInt(i64),
+    /// Represents a float.
+    Float(f64),
+}
+
+impl Number {
+    /// Represents the `Number` as f64 if possible. Returns None otherwise.
+    pub fn as_f64(&self) -> Option<f64> {
+        match *self {
+            Self::PosInt(n) => Some(n as f64),
+            Self::NegInt(n) => Some(n as f64),
+            Self::Float(n) => Some(n),
+        }
+    }
+
+    /// If the `Number` is an integer, represent it as i64 if possible. Returns None otherwise.
+    pub fn as_i64(&self) -> Option<i64> {
+        match *self {
+            Self::PosInt(n) => {
+                if n <= i64::max_value() as u64 {
+                    Some(n as i64)
+                } else {
+                    None
+                }
+            }
+            Self::NegInt(n) => Some(n),
+            Self::Float(_) => None,
+        }
+    }
+
+    /// If the `Number` is an integer, represent it as u64 if possible. Returns None otherwise.
+    pub fn as_u64(&self) -> Option<u64> {
+        match *self {
+            Self::PosInt(n) => Some(n),
+            Self::NegInt(_) | Self::Float(_) => None,
+        }
+    }
+
+    /// Returns true if the `Number` is a float.
+    ///
+    /// For any `Number` on which `is_f64` returns true, `as_f64` is guaranteed to return the
+    /// float value.
+    pub fn is_f64(&self) -> bool {
+        match self {
+            Self::Float(_) => true,
+            Self::PosInt(_) | Self::NegInt(_) => false,
+        }
+    }
+
+    /// Returns true if the `Number` is an integer between `i64::MIN` and `i64::MAX`.
+    ///
+    /// For any `Number` on which `is_i64` returns true, `as_i64` is guaranteed to return the
+    /// integer value.
+    pub fn is_i64(&self) -> bool {
+        match *self {
+            Self::PosInt(v) => v <= i64::max_value() as u64,
+            Self::NegInt(_) => true,
+            Self::Float(_) => false,
+        }
+    }
+
+    /// Returns true if the `Number` is an integer between zero and `u64::MAX`.
+    ///
+    /// For any `Number` on which `is_u64` returns true, `as_u64` is guaranteed to return the
+    /// integer value.
+    pub fn is_u64(&self) -> bool {
+        match self {
+            Self::PosInt(_) => true,
+            Self::NegInt(_) | Self::Float(_) => false,
+        }
+    }
+}
+
+macro_rules! impl_from_unsigned {
+    ($($ty:ty),*) => {
+        $(
+            impl From<$ty> for Number {
+                fn from(u: $ty) -> Self {
+                    Self::PosInt(u as u64)
+                }
+            }
+        )*
+    };
+}
+
+macro_rules! impl_from_signed {
+    ($($ty:ty),*) => {
+        $(
+            impl From<$ty> for Number {
+                fn from(i: $ty) -> Self {
+                    if i < 0 {
+                        Self::NegInt(i as i64)
+                    } else {
+                        Self::PosInt(i as u64)
+                    }
+                }
+            }
+        )*
+    };
+}
+
+impl_from_unsigned!(u8, u16, u32, u64, usize);
+impl_from_signed!(i8, i16, i32, i64, isize);
+
+impl From<f32> for Number {
+    fn from(f: f32) -> Self {
+        Self::Float(f as f64)
+    }
+}
+
+impl From<f64> for Number {
+    fn from(f: f64) -> Self {
+        Self::Float(f)
+    }
+}
+
+impl From<serde_json::Number> for Number {
+    fn from(n: serde_json::Number) -> Self {
+        if n.is_u64() {
+            Number::PosInt(n.as_u64().unwrap())
+        } else if n.is_i64() {
+            Number::NegInt(n.as_i64().unwrap())
+        } else {
+            Number::Float(n.as_f64().unwrap())
+        }
+    }
+}
+
+impl From<Number> for serde_json::Number {
+    fn from(n: Number) -> Self {
+        match n {
+            Number::PosInt(i) => i.into(),
+            Number::NegInt(i) => i.into(),
+            Number::Float(f) => serde_json::Number::from_f64(f).unwrap(),
+        }
+    }
+}
+
+impl Display for Number {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::PosInt(i) => Display::fmt(&i, formatter),
+            Self::NegInt(i) => Display::fmt(&i, formatter),
+            Self::Float(f) => Display::fmt(&f, formatter),
+        }
+    }
+}
+
+impl Serialize for Number {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match *self {
+            Self::PosInt(i) => serializer.serialize_u64(i),
+            Self::NegInt(i) => serializer.serialize_i64(i),
+            Self::Float(f) => serializer.serialize_f64(f),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Number {
+    fn deserialize<D>(deserializer: D) -> Result<Number, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct NumberVisitor;
+
+        impl<'de> Visitor<'de> for NumberVisitor {
+            type Value = Number;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a HCL number")
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<Number, E> {
+                Ok(value.into())
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<Number, E> {
+                Ok(value.into())
+            }
+
+            fn visit_f64<E>(self, value: f64) -> Result<Number, E> {
+                Ok(value.into())
+            }
+        }
+
+        deserializer.deserialize_any(NumberVisitor)
+    }
+}

--- a/crates/dts-core/src/ser.rs
+++ b/crates/dts-core/src/ser.rs
@@ -1,8 +1,7 @@
 //! This module provides a `Serializer` which supports serializing values into various output
 //! encodings.
 
-use crate::{Encoding, Error, Result, Value, ValueExt};
-use serde_json::Map;
+use crate::{Encoding, Error, Map, Result, Value, ValueExt};
 use std::iter;
 
 /// Options for the `Serializer`. The options are context specific and may only be honored when
@@ -127,8 +126,7 @@ where
     /// ## Example
     ///
     /// ```
-    /// use dts_core::{ser::SerializerBuilder, Encoding};
-    /// use serde_json::json;
+    /// use dts_core::{json, ser::SerializerBuilder, Encoding};
     /// # use std::error::Error;
     /// #
     /// # fn main() -> Result<(), Box<dyn Error>> {
@@ -278,8 +276,8 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::json;
     use pretty_assertions::assert_eq;
-    use serde_json::json;
 
     #[test]
     fn test_serialize_json() {

--- a/crates/dts-core/src/transform/key.rs
+++ b/crates/dts-core/src/transform/key.rs
@@ -1,6 +1,5 @@
 use crate::parsers::flat_key::StringKeyParts;
-use crate::Value;
-use serde_json::Map;
+use crate::{Map, Value};
 use std::collections::BTreeMap;
 
 pub struct KeyFlattener<'a> {
@@ -56,8 +55,8 @@ impl<'a> KeyFlattener<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::json;
     use pretty_assertions::assert_eq;
-    use serde_json::json;
 
     #[test]
     fn test_key_flattener() {

--- a/crates/dts-core/src/transform/sort.rs
+++ b/crates/dts-core/src/transform/sort.rs
@@ -1,6 +1,5 @@
 use super::TransformError;
-use crate::Value;
-use serde_json::{Map, Number};
+use crate::{Map, Number, Value};
 use std::cmp::{self, Ordering};
 use std::str::FromStr;
 
@@ -216,8 +215,9 @@ fn cmp_numbers(lhs: &Number, rhs: &Number) -> Ordering {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::json;
     use pretty_assertions::assert_eq;
-    use serde_json::{json, to_string_pretty};
+    use serde_json::to_string_pretty;
 
     #[track_caller]
     fn assert_eq_sorted(order: Order, max_depth: Option<u64>, mut given: Value, expected: Value) {

--- a/crates/dts-core/src/value/de.rs
+++ b/crates/dts-core/src/value/de.rs
@@ -14,7 +14,7 @@ impl<'de> Deserialize<'de> for Value {
             type Value = Value;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("any valid HCL value")
+                formatter.write_str("any valid value")
             }
 
             fn visit_bool<E>(self, value: bool) -> Result<Value, E> {

--- a/crates/dts-core/src/value/de.rs
+++ b/crates/dts-core/src/value/de.rs
@@ -1,0 +1,91 @@
+use super::{Map, Value};
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer};
+use std::fmt;
+
+impl<'de> Deserialize<'de> for Value {
+    fn deserialize<D>(deserializer: D) -> Result<Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ValueVisitor;
+
+        impl<'de> Visitor<'de> for ValueVisitor {
+            type Value = Value;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("any valid HCL value")
+            }
+
+            fn visit_bool<E>(self, value: bool) -> Result<Value, E> {
+                Ok(Value::Bool(value))
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<Value, E> {
+                Ok(Value::Number(value.into()))
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<Value, E> {
+                Ok(Value::Number(value.into()))
+            }
+
+            fn visit_f64<E>(self, value: f64) -> Result<Value, E> {
+                Ok(Value::Number(value.into()))
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Value, E>
+            where
+                E: serde::de::Error,
+            {
+                self.visit_string(value.to_owned())
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Value, E> {
+                Ok(Value::String(value))
+            }
+
+            fn visit_none<E>(self) -> Result<Value, E> {
+                Ok(Value::Null)
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> Result<Value, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                Deserialize::deserialize(deserializer)
+            }
+
+            fn visit_unit<E>(self) -> Result<Value, E> {
+                Ok(Value::Null)
+            }
+
+            fn visit_seq<V>(self, mut visitor: V) -> Result<Value, V::Error>
+            where
+                V: de::SeqAccess<'de>,
+            {
+                let mut vec = Vec::with_capacity(visitor.size_hint().unwrap_or(0));
+
+                while let Some(elem) = visitor.next_element()? {
+                    vec.push(elem);
+                }
+
+                Ok(Value::Array(vec))
+            }
+
+            fn visit_map<V>(self, mut visitor: V) -> Result<Value, V::Error>
+            where
+                V: de::MapAccess<'de>,
+            {
+                let mut map = Map::with_capacity(visitor.size_hint().unwrap_or(0));
+
+                while let Some((key, value)) = visitor.next_entry()? {
+                    map.insert(key, value);
+                }
+
+                Ok(Value::Object(map))
+            }
+        }
+
+        deserializer.deserialize_any(ValueVisitor)
+    }
+}

--- a/crates/dts-core/src/value/from.rs
+++ b/crates/dts-core/src/value/from.rs
@@ -1,0 +1,119 @@
+use super::{Map, Value};
+use std::borrow::Cow;
+
+macro_rules! impl_from_integer {
+    ($($ty:ty),*) => {
+        $(
+            impl From<$ty> for Value {
+                fn from(n: $ty) -> Self {
+                    Self::Number(n.into())
+                }
+            }
+        )*
+    };
+}
+
+impl_from_integer!(i8, i16, i32, i64, isize);
+impl_from_integer!(u8, u16, u32, u64, usize);
+
+impl From<f32> for Value {
+    fn from(f: f32) -> Self {
+        Self::Number(f.into())
+    }
+}
+
+impl From<f64> for Value {
+    fn from(f: f64) -> Self {
+        Self::Number(f.into())
+    }
+}
+
+impl From<bool> for Value {
+    fn from(b: bool) -> Self {
+        Self::Bool(b)
+    }
+}
+
+impl From<String> for Value {
+    fn from(s: String) -> Self {
+        Self::String(s)
+    }
+}
+
+impl From<&str> for Value {
+    fn from(s: &str) -> Self {
+        Self::String(s.to_string())
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for Value {
+    fn from(s: Cow<'a, str>) -> Self {
+        Self::String(s.into_owned())
+    }
+}
+
+impl From<Map<String, Value>> for Value {
+    fn from(f: Map<String, Value>) -> Self {
+        Self::Object(f)
+    }
+}
+
+impl<T: Into<Value>> From<Vec<T>> for Value {
+    fn from(f: Vec<T>) -> Self {
+        Self::Array(f.into_iter().map(Into::into).collect())
+    }
+}
+
+impl<'a, T: Clone + Into<Value>> From<&'a [T]> for Value {
+    fn from(f: &'a [T]) -> Self {
+        Self::Array(f.iter().cloned().map(Into::into).collect())
+    }
+}
+
+impl<T: Into<Value>> FromIterator<T> for Value {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self::Array(iter.into_iter().map(Into::into).collect())
+    }
+}
+
+impl<K: Into<String>, V: Into<Value>> FromIterator<(K, V)> for Value {
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
+        Self::Object(
+            iter.into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        )
+    }
+}
+
+impl From<()> for Value {
+    fn from((): ()) -> Self {
+        Self::Null
+    }
+}
+
+impl From<serde_json::Value> for Value {
+    fn from(v: serde_json::Value) -> Self {
+        match v {
+            serde_json::Value::Null => Value::Null,
+            serde_json::Value::Bool(b) => Value::Bool(b),
+            serde_json::Value::Number(n) => Value::Number(n.into()),
+            serde_json::Value::String(s) => Value::String(s),
+            serde_json::Value::Array(a) => Value::from_iter(a),
+            serde_json::Value::Object(o) => Value::from_iter(o),
+        }
+    }
+}
+
+impl From<Value> for serde_json::Value {
+    fn from(v: Value) -> Self {
+        match v {
+            Value::Null => serde_json::Value::Null,
+            Value::Bool(b) => serde_json::Value::Bool(b),
+            Value::Number(n) => serde_json::Value::Number(n.into()),
+            Value::String(s) => serde_json::Value::String(s),
+            Value::Array(a) => serde_json::Value::from_iter(a),
+            Value::Object(o) => serde_json::Value::from_iter(o),
+        }
+    }
+}

--- a/crates/dts-core/src/value/mod.rs
+++ b/crates/dts-core/src/value/mod.rs
@@ -1,4 +1,4 @@
-//! The Value enum, a loosely typed way of representing any valid HCL value.
+//! The Value enum, a loosely typed way of representing any valid value.
 
 mod de;
 mod from;
@@ -13,23 +13,23 @@ use std::str;
 
 pub use crate::number::Number;
 
-/// The map type used for HCL objects.
+/// The map type used for objects.
 pub type Map<K, V> = indexmap::IndexMap<K, V>;
 
-/// Represents any valid HCL value.
+/// Represents any valid value.
 #[derive(Debug, PartialEq, Clone)]
 pub enum Value {
-    /// Represents a HCL null value.
+    /// Represents a null value.
     Null,
-    /// Represents a HCL boolean.
+    /// Represents a boolean.
     Bool(bool),
-    /// Represents a HCL number, either integer or float.
+    /// Represents a number, either integer or float.
     Number(Number),
-    /// Represents a HCL string.
+    /// Represents a string.
     String(String),
-    /// Represents a HCL array.
+    /// Represents a array.
     Array(Vec<Value>),
-    /// Represents a HCL object.
+    /// Represents a object.
     Object(Map<String, Value>),
 }
 

--- a/crates/dts-core/src/value/mod.rs
+++ b/crates/dts-core/src/value/mod.rs
@@ -1,0 +1,333 @@
+//! The Value enum, a loosely typed way of representing any valid HCL value.
+
+mod de;
+mod from;
+mod ser;
+
+use serde::ser::Serialize;
+use serde_json::error::Error;
+use serde_json::value::Serializer;
+use std::fmt;
+use std::io;
+use std::str;
+
+pub use crate::number::Number;
+
+/// The map type used for HCL objects.
+pub type Map<K, V> = indexmap::IndexMap<K, V>;
+
+/// Represents any valid HCL value.
+#[derive(Debug, PartialEq, Clone)]
+pub enum Value {
+    /// Represents a HCL null value.
+    Null,
+    /// Represents a HCL boolean.
+    Bool(bool),
+    /// Represents a HCL number, either integer or float.
+    Number(Number),
+    /// Represents a HCL string.
+    String(String),
+    /// Represents a HCL array.
+    Array(Vec<Value>),
+    /// Represents a HCL object.
+    Object(Map<String, Value>),
+}
+
+impl Default for Value {
+    fn default() -> Value {
+        Value::Null
+    }
+}
+
+impl Value {
+    /// If the `Value` is an Array, returns the associated vector. Returns None
+    /// otherwise.
+    pub fn as_array(&self) -> Option<&Vec<Value>> {
+        match self {
+            Self::Array(array) => Some(array),
+            _ => None,
+        }
+    }
+
+    /// If the `Value` is an Array, returns the associated mutable vector.
+    /// Returns None otherwise.
+    pub fn as_array_mut(&mut self) -> Option<&mut Vec<Value>> {
+        match self {
+            Self::Array(array) => Some(array),
+            _ => None,
+        }
+    }
+
+    /// If the `Value` is a Boolean, represent it as bool if possible. Returns
+    /// None otherwise.
+    pub fn as_bool(&self) -> Option<bool> {
+        match *self {
+            Self::Bool(b) => Some(b),
+            _ => None,
+        }
+    }
+
+    /// If the `Value` is a Number, represent it as f64 if possible. Returns
+    /// None otherwise.
+    pub fn as_f64(&self) -> Option<f64> {
+        self.as_number().and_then(|n| n.as_f64())
+    }
+
+    /// If the `Value` is a Number, represent it as i64 if possible. Returns
+    /// None otherwise.
+    pub fn as_i64(&self) -> Option<i64> {
+        self.as_number().and_then(|n| n.as_i64())
+    }
+
+    /// If the `Value` is a Null, returns (). Returns None otherwise.
+    pub fn as_null(&self) -> Option<()> {
+        match self {
+            Self::Null => Some(()),
+            _ => None,
+        }
+    }
+
+    /// If the `Value` is a Number, returns the associated Number. Returns None
+    /// otherwise.
+    pub fn as_number(&self) -> Option<&Number> {
+        match self {
+            Self::Number(num) => Some(num),
+            _ => None,
+        }
+    }
+
+    /// If the `Value` is an Object, returns the associated Map. Returns None
+    /// otherwise.
+    pub fn as_object(&self) -> Option<&Map<String, Value>> {
+        match self {
+            Self::Object(object) => Some(object),
+            _ => None,
+        }
+    }
+
+    /// If the `Value` is an Object, returns the associated mutable Map.
+    /// Returns None otherwise.
+    pub fn as_object_mut(&mut self) -> Option<&mut Map<String, Value>> {
+        match self {
+            Self::Object(object) => Some(object),
+            _ => None,
+        }
+    }
+
+    /// If the `Value` is a String, returns the associated str. Returns None
+    /// otherwise.
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Self::String(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// If the `Value` is a Number, represent it as u64 if possible. Returns
+    /// None otherwise.
+    pub fn as_u64(&self) -> Option<u64> {
+        self.as_number().and_then(|n| n.as_u64())
+    }
+
+    /// Returns true if the `Value` is an Array. Returns false otherwise.
+    ///
+    /// For any Value on which `is_array` returns true, `as_array` and
+    /// `as_array_mut` are guaranteed to return the vector representing the
+    /// array.
+    pub fn is_array(&self) -> bool {
+        self.as_array().is_some()
+    }
+
+    /// Returns true if the `Value` is a Boolean. Returns false otherwise.
+    ///
+    /// For any Value on which `is_boolean` returns true, `as_bool` is
+    /// guaranteed to return the boolean value.
+    pub fn is_boolean(&self) -> bool {
+        self.as_bool().is_some()
+    }
+
+    /// Returns true if the `Value` is a number that can be represented by f64.
+    ///
+    /// For any Value on which `is_f64` returns true, `as_f64` is guaranteed to
+    /// return the floating point value.
+    pub fn is_f64(&self) -> bool {
+        self.as_number().map(Number::is_f64).unwrap_or(false)
+    }
+
+    /// Returns true if the `Value` is an integer between `i64::MIN` and
+    /// `i64::MAX`.
+    ///
+    /// For any Value on which `is_i64` returns true, `as_i64` is guaranteed to
+    /// return the integer value.
+    pub fn is_i64(&self) -> bool {
+        self.as_number().map(Number::is_i64).unwrap_or(false)
+    }
+
+    /// Returns true if the `Value` is a Number. Returns false otherwise.
+    pub fn is_number(&self) -> bool {
+        self.as_number().is_some()
+    }
+
+    /// Returns true if the `Value` is a Null. Returns false otherwise.
+    ///
+    /// For any Value on which `is_null` returns true, `as_null` is guaranteed
+    /// to return `Some(())`.
+    pub fn is_null(&self) -> bool {
+        self.as_null().is_some()
+    }
+
+    /// Returns true if the `Value` is an Object. Returns false otherwise.
+    ///
+    /// For any Value on which `is_object` returns true, `as_object` and
+    /// `as_object_mut` are guaranteed to return the map representation of the
+    /// object.
+    pub fn is_object(&self) -> bool {
+        self.as_object().is_some()
+    }
+
+    /// Returns true if the `Value` is a String. Returns false otherwise.
+    ///
+    /// For any Value on which `is_string` returns true, `as_str` is guaranteed
+    /// to return the string slice.
+    pub fn is_string(&self) -> bool {
+        self.as_str().is_some()
+    }
+
+    /// Returns true if the `Value` is an integer between zero and `u64::MAX`.
+    ///
+    /// For any Value on which `is_u64` returns true, `as_u64` is guaranteed to
+    /// return the integer value.
+    pub fn is_u64(&self) -> bool {
+        self.as_number().map(Number::is_u64).unwrap_or(false)
+    }
+
+    /// Takes the value out of the `Value`, leaving a `Null` in its place.
+    pub fn take(&mut self) -> Value {
+        std::mem::replace(self, Value::Null)
+    }
+}
+
+impl fmt::Display for Value {
+    /// Display a JSON value as a string.
+    ///
+    /// ```
+    /// # use dts_core::json;
+    /// #
+    /// let json = json!({ "city": "London", "street": "10 Downing Street" });
+    ///
+    /// // Compact format:
+    /// //
+    /// // {"city":"London","street":"10 Downing Street"}
+    /// let compact = format!("{}", json);
+    /// assert_eq!(compact,
+    ///     "{\"city\":\"London\",\"street\":\"10 Downing Street\"}");
+    ///
+    /// // Pretty format:
+    /// //
+    /// // {
+    /// //   "city": "London",
+    /// //   "street": "10 Downing Street"
+    /// // }
+    /// let pretty = format!("{:#}", json);
+    /// assert_eq!(pretty,
+    ///     "{\n  \"city\": \"London\",\n  \"street\": \"10 Downing Street\"\n}");
+    /// ```
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        struct WriterFormatter<'a, 'b: 'a> {
+            inner: &'a mut fmt::Formatter<'b>,
+        }
+
+        impl<'a, 'b> io::Write for WriterFormatter<'a, 'b> {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                // Safety: the serializer below only emits valid utf8 when using
+                // the default formatter.
+                let s = unsafe { str::from_utf8_unchecked(buf) };
+                self.inner.write_str(s).map_err(io_error)?;
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        fn io_error(_: fmt::Error) -> io::Error {
+            // Error value does not matter because Display impl just maps it
+            // back to fmt::Error.
+            io::Error::new(io::ErrorKind::Other, "fmt error")
+        }
+
+        let alternate = f.alternate();
+        let mut wr = WriterFormatter { inner: f };
+        if alternate {
+            // {:#}
+            serde_json::to_writer_pretty(&mut wr, self).map_err(|_| fmt::Error)
+        } else {
+            // {}
+            serde_json::to_writer(&mut wr, self).map_err(|_| fmt::Error)
+        }
+    }
+}
+
+/// Convert a `T` into `dts_core::Value` which is an enum that can represent
+/// any valid JSON data.
+///
+/// # Example
+///
+/// ```
+/// use serde::Serialize;
+/// use dts_core::json;
+///
+/// use std::error::Error;
+///
+/// #[derive(Serialize)]
+/// struct User {
+///     fingerprint: String,
+///     location: String,
+/// }
+///
+/// fn compare_json_values() -> Result<(), Box<dyn Error>> {
+///     let u = User {
+///         fingerprint: "0xF9BA143B95FF6D82".to_owned(),
+///         location: "Menlo Park, CA".to_owned(),
+///     };
+///
+///     // The type of `expected` is `dts_core::Value`
+///     let expected = json!({
+///         "fingerprint": "0xF9BA143B95FF6D82",
+///         "location": "Menlo Park, CA",
+///     });
+///
+///     let v = dts_core::to_value(u).unwrap();
+///     assert_eq!(v, expected);
+///
+///     Ok(())
+/// }
+/// #
+/// # compare_json_values().unwrap();
+/// ```
+///
+/// # Errors
+///
+/// This conversion can fail if `T`'s implementation of `Serialize` decides to
+/// fail, or if `T` contains a map with non-string keys.
+///
+/// ```
+/// use std::collections::BTreeMap;
+///
+/// fn main() {
+///     // The keys in this map are vectors, not strings.
+///     let mut map = BTreeMap::new();
+///     map.insert(vec![32, 64], "x86");
+///
+///     println!("{}", dts_core::to_value(map).unwrap_err());
+/// }
+/// ```
+// Taking by value is more friendly to iterator adapters, option and result
+// consumers, etc. See https://github.com/serde-rs/json/pull/149.
+pub fn to_value<T>(value: T) -> Result<Value, Error>
+where
+    T: Serialize,
+{
+    value.serialize(Serializer).map(Into::into)
+}

--- a/crates/dts-core/src/value/ser.rs
+++ b/crates/dts-core/src/value/ser.rs
@@ -1,0 +1,18 @@
+use super::Value;
+use serde::ser::{Serialize, Serializer};
+
+impl Serialize for Value {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match *self {
+            Value::Null => serializer.serialize_unit(),
+            Value::Bool(b) => serializer.serialize_bool(b),
+            Value::Number(ref n) => n.serialize(serializer),
+            Value::String(ref s) => serializer.serialize_str(s),
+            Value::Array(ref v) => v.serialize(serializer),
+            Value::Object(ref v) => v.serialize(serializer),
+        }
+    }
+}

--- a/crates/dts-core/src/value/traits.rs
+++ b/crates/dts-core/src/value/traits.rs
@@ -1,0 +1,13 @@
+impl JsonPathQuery for Box<Value> {
+    fn path(self, query: &str) -> Result<Value, String> {
+        let p = JsonPathInst::from_str(query)?;
+        Ok(JsonPathFinder::new(self, Box::new(p)).find())
+    }
+}
+
+impl JsonPathQuery for Value {
+    fn path(self, query: &str) -> Result<Value, String> {
+        let p = JsonPathInst::from_str(query)?;
+        Ok(JsonPathFinder::new(Box::from(self), Box::new(p)).find())
+    }
+}


### PR DESCRIPTION
**NOTE:** this PR is a heavy WIP and will get quite large due to the big 
number of changes needed to be made at once. Some implementations 
are still hacky and need to be polished.

This is meant as a replacement for the internal usage of
`serde_json::Value`. The main issue with `serde_json::Value` is that we
are now at a point where we need features that it does not have and
which we cannot implement cleanly because `serde_json` is a foreign
crate.

For example, `serde_json::Value` is neither `Hash` nor `PartialOrd` or
`Ord`. We cannot implement these traits for it because both the type and
the traits are foreign.

For the latter two we did a nasty workaround. Other features like
deep merging we added via a `ValueExt` trait.