### PR TITLE
chore!(dts-core/parsers): remove support for legacy args and unquoted strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ the same option possible):
 
 ```sh
 # This uses the single char forms of the transformation options
-dts tests/fixtures/example.json -t "delete_keys('some_key').deep_merge.jp('[*]'),flatten,jsonpath('[*].id')"
+dts tests/fixtures/example.json -t "delete_keys('some_key').deep_merge.jp('[*]').flatten.jsonpath('[*].id')"
 ```
 
 Read data from stdin:
 
 ```sh
-echo '{"foo": {"bar": "baz"}}' | dts -i json -tF,r -o yaml
+echo '{"foo": {"bar": "baz"}}' | dts -i json -tF.r -o yaml
 ```
 
 ## Output colors and themes

--- a/crates/dts-core/src/parsers/grammars/func_sig.pest
+++ b/crates/dts-core/src/parsers/grammars/func_sig.pest
@@ -1,12 +1,18 @@
 // Whitespace
 WHITESPACE = _{ " " | "\t" | NEWLINE }
 
-// String values
+// String literals
+StringLit   = _{ StringLitDq | StringLitSq }
 StringLitDq = _{ "\"" ~ StringDq ~ "\"" }
 StringLitSq = _{ "'" ~ StringSq ~ "'" }
-String      =  { (!("(" | ")" | ",") ~ ANY)+ }
-StringDq    =  { (("\\" ~ ("\"" | "\\")) | (!"\"" ~ ANY))* }
-StringSq    =  { (("\\" ~ ("'" | "\\")) | (!"'" ~ ANY))* }
+StringDq    = @{ (("\\" ~ ("\"" | "\\")) | (!"\"" ~ ANY))* }
+StringSq    = @{ (("\\" ~ ("'" | "\\")) | (!"'" ~ ANY))* }
+
+// Other literals
+BooleanLit =  { "true" | "false" }
+NumericLit = @{ "-"? ~ Decimal+ ~ (("." ~ Decimal+ ~ (ExpMark ~ Decimal+)?) | (ExpMark ~ Decimal+))? }
+ExpMark    =  { ("e" | "E") ~ ("+" | "-")? }
+Decimal    =  { '0'..'9' }
 
 // Identifiers
 Identifier     = @{ IdentFirstChar ~ IdentChar* }
@@ -16,22 +22,15 @@ Letter         = _{ 'a'..'z' | 'A'..'Z' }
 
 // Funcs
 FuncSigs  = _{ FuncSig ~ (FuncDelim? ~ FuncSig)* }
-FuncSig   =  { Identifier ~ (ArgsSig | LegacyArgsSig)? }
-FuncDelim = _{ ";" | "," | "." }
+FuncSig   =  { Identifier ~ ArgsSig? }
+FuncDelim = _{ "." }
 
 // Args
 ArgsSig       = _{ "(" ~ Args? ~ ")" }
 Args          =  { Arg ~ ("," ~ Arg)* }
 Arg           = _{ NamedArg | PositionalArg }
-ArgValue      = _{ StringLitDq | StringLitSq | String }
+ArgValue      = _{ StringLit | NumericLit | BooleanLit }
 NamedArg      =  { Identifier ~ "=" ~ ArgValue }
 PositionalArg =  { ArgValue }
-
-// Legacy Args
-LegacyArgsSig  = _{ "=" ~ LegacyArgs }
-LegacyArgs     =  { LegacyArg ~ (":" ~ LegacyArg)* }
-LegacyArg      =  { LegacyArgValue }
-LegacyArgValue = _{ StringLitDq | StringLitSq | LegacyString }
-LegacyString   =  { (!("(" | ")" | ":" | ",") ~ ANY)+ }
 
 Root = _{ SOI ~ FuncSigs ~ EOI }

--- a/crates/dts/transform.rs
+++ b/crates/dts/transform.rs
@@ -203,7 +203,7 @@ where
         deserialized into an internal representation that resembles JSON.
 
         A transformation expression containing one or more transformation functions separated
-        either by '.', ';', ',' or spaces.
+        either by '.' or spaces.
 
         Transformation functions may have one of the following forms:
 
@@ -213,13 +213,13 @@ where
             function_name(arg1, arg2)        # multiple arguments
             function_name(arg2=value, arg1)  # named argument in different position
 
-        Function arguments may be numbers, raw string identifiers or quoted strings.
+        Function arguments may be quoted string, numbers or booleans.
     "#})?;
     printer.write("\n")?;
     printer.write_colored(ColorSpec::new().set_fg(Some(Color::Yellow)), "EXAMPLE:")?;
     printer.write("\n")?;
     printer.write(indent(
-        r#"dts input.json --transform 'jsonpath("$.selector").flatten.sort(order=asc)' -o toml"#,
+        r#"dts input.json --transform 'jsonpath("$.selector").flatten.sort(order="asc")' -o toml"#,
         4,
     ))?;
     printer.write("\n\n")?;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -52,7 +52,7 @@ fn json_to_csv_filtered_flattened_with_keys() {
     Command::cargo_bin("dts")
         .unwrap()
         .arg("tests/fixtures/example.json")
-        .args(&["-o", "csv", "-t", "jsonpath($..friends),flatten", "-K"])
+        .args(&["-o", "csv", "-t", "jsonpath('$..friends').flatten", "-K"])
         .assert()
         .success()
         .stdout(read("tests/fixtures/friends.csv").unwrap());
@@ -63,7 +63,7 @@ fn json_to_csv_collections_as_json() {
     Command::cargo_bin("dts")
         .unwrap()
         .arg("tests/fixtures/example.json")
-        .args(&["-o", "csv", "-t", "jsonpath($.users[*])", "-K"])
+        .args(&["-o", "csv", "-t", "jsonpath('$.users[*]')", "-K"])
         .assert()
         .success()
         .stdout(read("tests/fixtures/users.csv").unwrap());
@@ -74,7 +74,7 @@ fn json_to_gron() {
     Command::cargo_bin("dts")
         .unwrap()
         .arg("tests/fixtures/example.json")
-        .args(&["-t", "flatten_keys(json)", "-o", "gron"])
+        .args(&["-t", "flatten_keys('json')", "-o", "gron"])
         .assert()
         .success()
         .stdout(read("tests/fixtures/example.js").unwrap());
@@ -134,7 +134,7 @@ fn deep_merge_json() {
     Command::cargo_bin("dts")
         .unwrap()
         .arg("tests/fixtures/example.json")
-        .args(&["-t", "jsonpath($.users).flatten.deep_merge", "-n"])
+        .args(&["-t", "jsonpath('$.users').flatten.deep_merge", "-n"])
         .assert()
         .success()
         .stdout(read("tests/fixtures/example.merged.json").unwrap());
@@ -152,7 +152,7 @@ fn continue_on_error() {
             "-i",
             "json",
             "-t",
-            "jsonpath($[*].users),flatten,deep_merge",
+            "jsonpath('$[*].users').flatten.deep_merge",
             "-n",
         ])
         .assert()
@@ -166,7 +166,7 @@ fn continue_on_error() {
             "-i",
             "json",
             "-t",
-            "jsonpath($[*].users),flatten,deep_merge",
+            "jsonpath('$[*].users').flatten.deep_merge",
             "-n",
             "--continue-on-error",
         ])


### PR DESCRIPTION
This will enable us to implement arguments that are expressions.

For example, we could implement something like this:

    mutate('$.users', remove_empty_values().flatten())