### PR TITLE
feat(dts-core): add `Transform` trait

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -88,7 +88,7 @@ fn benchmark_transform(c: &mut Criterion) {
                     "*",
                     "-C",
                     "-t",
-                    "flatten_keys(json),expand_keys,jsonpath($.json),flatten",
+                    "flatten_keys('json').expand_keys.jsonpath('$.json').flatten",
                 ])
                 .assert()
                 .success()

--- a/crates/dts/main.rs
+++ b/crates/dts/main.rs
@@ -21,7 +21,7 @@ use anyhow::{anyhow, Context, Result};
 use clap::{App, IntoApp, Parser};
 use clap_generate::{generate, Shell};
 use dts_core::{
-    de::Deserializer, ser::Serializer, transform::apply_chain, Encoding, Error, Sink, Source,
+    de::Deserializer, ser::Serializer, transform::Transform, Encoding, Error, Sink, Source,
 };
 use dts_json::Value;
 use rayon::prelude::*;
@@ -77,7 +77,7 @@ fn deserialize_many(sources: &[Source], opts: &InputOptions) -> Result<Value> {
 
 fn transform(value: Value, opts: &TransformOptions) -> Result<Value> {
     parse_expressions(&opts.expressions)
-        .map(|chain| apply_chain(&chain, value))
+        .map(|chain| chain.transform(value))
         .context("Failed to build transformation chain")
 }
 


### PR DESCRIPTION
The `Transformation` type got quite large and is not flexible enough for
some transformations that will be added in the future.

To fix this, the `Transform` trait was added and dynamic dispatch over
this type will be used. This will allow for a more modular design where
specialized transformations can have their dedicated type.