### PR TITLE
feat(dts-core/transform): nested expressions and `mutate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,24 +51,28 @@ Load all YAML files from sub directories, flatten nested arrays and merge them i
 dts . --glob '**/*.yaml' -t flatten output.yaml
 ```
 
-Run a JSONPath filter on the input data:
+Select a subset of the input data via JSONPath query:
 
 ```sh
-dts tests/fixtures/example.json -t 'jsonpath("$.users[?(@.age < 30)]")'
+dts tests/fixtures/example.json -t 'select("$.users[?(@.age < 30)]")'
 ```
 
-Combine multiple transformation options (multiple usages and short aliases of
-the same option possible):
+Mutate just a subset of the input data:
 
 ```sh
-# This uses the single char forms of the transformation options
-dts tests/fixtures/example.json -t "delete_keys('some_key').deep_merge.jp('[*]').flatten.jsonpath('[*].id')"
+dts tests/fixtures/example.json -t 'mutate("$.users[?(@.age > 30)]", sort().flatten())'
+```
+
+Combine multiple transformation options:
+
+```sh
+dts tests/fixtures/example.json -t "delete_keys('some_key').deep_merge.select('[*]').flatten.select('[*].id')"
 ```
 
 Read data from stdin:
 
 ```sh
-echo '{"foo": {"bar": "baz"}}' | dts -i json -tF.r -o yaml
+echo '{"foo": {"bar": "baz"}}' | dts -i json -o yaml
 ```
 
 ## Output colors and themes

--- a/crates/dts-core/src/parsers/func_sig.rs
+++ b/crates/dts-core/src/parsers/func_sig.rs
@@ -5,11 +5,39 @@ use crate::Result;
 use pest::iterators::{Pair, Pairs};
 use pest::Parser as ParseTrait;
 use pest_derive::Parser;
-use std::fmt;
+use std::fmt::{self, Write};
 
 #[derive(Parser)]
 #[grammar = "parsers/grammars/func_sig.pest"]
 struct FuncSigParser;
+
+/// Represents an expression.
+#[derive(Debug, PartialEq)]
+pub enum ExprTerm<'a> {
+    /// An expression consisting of one or more function signatures.
+    Expr(Vec<FuncSig<'a>>),
+    /// A value.
+    Value(&'a str),
+}
+
+impl<'a> fmt::Display for ExprTerm<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ExprTerm::Value(value) => write!(f, "\"{}\"", value),
+            ExprTerm::Expr(sigs) => {
+                for (i, sig) in sigs.iter().enumerate() {
+                    if i > 0 {
+                        f.write_char('.')?;
+                    }
+
+                    f.write_str(&sig.to_string())?;
+                }
+
+                Ok(())
+            }
+        }
+    }
+}
 
 /// Parses function calls from a `&str`.
 pub fn parse(input: &str) -> Result<Vec<FuncSig>, ParseError> {
@@ -47,13 +75,30 @@ fn parse_func_arg(pair: Pair<Rule>) -> FuncArg {
 
     match rule {
         Rule::PositionalArg => {
-            let value = inner.next().unwrap().as_str();
-            FuncArg::Positional(value)
+            let expr_term = parse_expr_term(inner.next().unwrap());
+            FuncArg::Positional(expr_term)
         }
         Rule::NamedArg => {
             let name = inner.next().unwrap().as_str();
-            let value = inner.next().unwrap().as_str();
-            FuncArg::Named(name, value)
+            let expr_term = parse_expr_term(inner.next().unwrap());
+            FuncArg::Named(name, expr_term)
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn parse_expr_term(pair: Pair<Rule>) -> ExprTerm {
+    let pair = pair.into_inner().next().unwrap();
+    let rule = pair.as_rule();
+    let mut inner = pair.into_inner();
+
+    match rule {
+        Rule::Value => ExprTerm::Value(inner.next().unwrap().as_str()),
+        Rule::Expr => {
+            let func_sigs = inner
+                .map(|pair| parse_func_sig(pair.into_inner()))
+                .collect();
+            ExprTerm::Expr(func_sigs)
         }
         _ => unreachable!(),
     }
@@ -108,15 +153,15 @@ impl<'a> fmt::Display for FuncSig<'a> {
 #[derive(Debug, PartialEq)]
 pub enum FuncArg<'a> {
     /// Represents a named argument (e.g. `name=value`).
-    Named(&'a str, &'a str),
+    Named(&'a str, ExprTerm<'a>),
     /// Represents a positional argument (e.g. `value`).
-    Positional(&'a str),
+    Positional(ExprTerm<'a>),
 }
 
 impl<'a> fmt::Display for FuncArg<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            FuncArg::Named(name, value) => write!(f, "{}=\"{}\"", name, value),
+            FuncArg::Named(name, value) => write!(f, "{}={}", name, value),
             FuncArg::Positional(value) => write!(f, "\"{}\"", value),
         }
     }
@@ -138,26 +183,41 @@ mod test {
         assert_parse("foo()", vec![FuncSig::new("foo", vec![])]);
         assert_parse(
             "foo(1)",
-            vec![FuncSig::new("foo", vec![FuncArg::Positional("1")])],
+            vec![FuncSig::new(
+                "foo",
+                vec![FuncArg::Positional(ExprTerm::Value("1"))],
+            )],
         );
         assert_parse(
             "foo(-1.0e10)",
-            vec![FuncSig::new("foo", vec![FuncArg::Positional("-1.0e10")])],
+            vec![FuncSig::new(
+                "foo",
+                vec![FuncArg::Positional(ExprTerm::Value("-1.0e10"))],
+            )],
         );
         assert_parse(
             "foo(true, false)",
             vec![FuncSig::new(
                 "foo",
-                vec![FuncArg::Positional("true"), FuncArg::Positional("false")],
+                vec![
+                    FuncArg::Positional(ExprTerm::Value("true")),
+                    FuncArg::Positional(ExprTerm::Value("false")),
+                ],
             )],
         );
         assert_parse(
             "foo('bar')",
-            vec![FuncSig::new("foo", vec![FuncArg::Positional("bar")])],
+            vec![FuncSig::new(
+                "foo",
+                vec![FuncArg::Positional(ExprTerm::Value("bar"))],
+            )],
         );
         assert_parse(
             "foo(\"bar\")",
-            vec![FuncSig::new("foo", vec![FuncArg::Positional("bar")])],
+            vec![FuncSig::new(
+                "foo",
+                vec![FuncArg::Positional(ExprTerm::Value("bar"))],
+            )],
         );
     }
 
@@ -168,9 +228,9 @@ mod test {
             vec![FuncSig {
                 name: "foo",
                 args: vec![
-                    FuncArg::Positional("bar"),
-                    FuncArg::Named("other", "qux"),
-                    FuncArg::Named("three", "4"),
+                    FuncArg::Positional(ExprTerm::Value("bar")),
+                    FuncArg::Named("other", ExprTerm::Value("qux")),
+                    FuncArg::Named("three", ExprTerm::Value("4")),
                 ],
             }],
         );
@@ -188,7 +248,7 @@ mod test {
                 },
                 FuncSig {
                     name: "baz",
-                    args: vec![FuncArg::Positional("qux")],
+                    args: vec![FuncArg::Positional(ExprTerm::Value("qux"))],
                 },
             ],
         );
@@ -197,8 +257,33 @@ mod test {
     #[test]
     fn test_parse_errors() {
         assert!(parse("foo.[").is_err());
-        assert!(parse("foo(bar)").is_err());
         assert!(parse("foo('baz)").is_err());
-        assert!(parse("foo(bar=baz)").is_err());
+    }
+
+    #[test]
+    fn test_parse_expression() {
+        assert_parse(
+            "foo(bar, baz('qux', 1), qux = fn().other_fn())",
+            vec![FuncSig::new(
+                "foo",
+                vec![
+                    FuncArg::Positional(ExprTerm::Expr(vec![FuncSig::new("bar", vec![])])),
+                    FuncArg::Positional(ExprTerm::Expr(vec![FuncSig::new(
+                        "baz",
+                        vec![
+                            FuncArg::Positional(ExprTerm::Value("qux")),
+                            FuncArg::Positional(ExprTerm::Value("1")),
+                        ],
+                    )])),
+                    FuncArg::Named(
+                        "qux",
+                        ExprTerm::Expr(vec![
+                            FuncSig::new("fn", vec![]),
+                            FuncSig::new("other_fn", vec![]),
+                        ]),
+                    ),
+                ],
+            )],
+        );
     }
 }

--- a/crates/dts-core/src/parsers/grammars/func_sig.pest
+++ b/crates/dts-core/src/parsers/grammars/func_sig.pest
@@ -20,6 +20,10 @@ IdentChar      = _{ Letter | '0'..'9' | "-" | "_" }
 IdentFirstChar = _{ Letter | "_" }
 Letter         = _{ 'a'..'z' | 'A'..'Z' }
 
+// Expressions
+Expr     =  { FuncSigs }
+ExprTerm =  { Value | "(" ~ Expr ~ ")" | Expr }
+
 // Funcs
 FuncSigs  = _{ FuncSig ~ (FuncDelim? ~ FuncSig)* }
 FuncSig   =  { Identifier ~ ArgsSig? }
@@ -29,8 +33,10 @@ FuncDelim = _{ "." }
 ArgsSig       = _{ "(" ~ Args? ~ ")" }
 Args          =  { Arg ~ ("," ~ Arg)* }
 Arg           = _{ NamedArg | PositionalArg }
-ArgValue      = _{ StringLit | NumericLit | BooleanLit }
-NamedArg      =  { Identifier ~ "=" ~ ArgValue }
-PositionalArg =  { ArgValue }
+NamedArg      =  { Identifier ~ "=" ~ ExprTerm }
+PositionalArg =  { ExprTerm }
+
+// Values
+Value = { StringLit | NumericLit | BooleanLit }
 
 Root = _{ SOI ~ FuncSigs ~ EOI }

--- a/crates/dts-core/src/transform/jsonpath.rs
+++ b/crates/dts-core/src/transform/jsonpath.rs
@@ -78,7 +78,7 @@ impl JsonPathMutator {
         let mut selector = SelectorMut::new();
 
         selector
-            .str_path(&query)
+            .str_path(query)
             .map_err(|err| Error::new(format!("Failed to parse jsonpath query:\n\n{}", err)))?;
 
         Ok(JsonPathMutator {

--- a/crates/dts-core/src/transform/mod.rs
+++ b/crates/dts-core/src/transform/mod.rs
@@ -86,7 +86,7 @@ pub struct Mutate {
 }
 
 impl Mutate {
-    /// @TODO
+    /// Creates a new `Mutate`.
     pub fn new(mutator: JsonPathMutator, chain: Chain) -> Self {
         Mutate { mutator, chain }
     }

--- a/crates/dts/transform.rs
+++ b/crates/dts/transform.rs
@@ -2,17 +2,28 @@ use crate::output::{BufferedStdoutPrinter, ColorChoice};
 use anyhow::{anyhow, Result};
 use dts_core::transform::{
     dsl::{Arg, Definition, DefinitionMatch, Definitions},
+    jsonpath::JsonPathMutator,
     sort::ValueSorter,
-    Chain, Transform, Transformation,
+    Chain, Mutate, Transform, Transformation,
 };
 use indoc::indoc;
 use termcolor::{Color, ColorSpec};
 
 pub fn definitions<'a>() -> Definitions<'a> {
+    let query_arg = Arg::new("query").with_description(indoc! {r#"
+        A jsonpath query.
+
+        See <https://goessner.net/articles/JsonPath/> for supported operators.
+    "#});
+
+    let expression_arg = Arg::new("expression").with_description(indoc! {r#"
+        An expression consisting of one or more transformation functions.
+    "#});
+
     Definitions::new()
         .add_definition(
             Definition::new("jsonpath")
-                .add_aliases(&["j", "jp"])
+                .add_aliases(&["j", "jp", "select"])
                 .with_description(indoc! {r#"
                     Selects data from the decoded input via jsonpath query. Can be specified multiple times to
                     allow starting the filtering from the root element again.
@@ -21,13 +32,7 @@ pub fn definitions<'a>() -> Definitions<'a> {
                     more elements. See `flatten` if you want to remove one level of nesting on single element
                     filter results.
                 "#})
-                .add_arg(
-                    Arg::new("query")
-                        .with_description(indoc! {r#"
-                            A jsonpath query.
-
-                            See <https://goessner.net/articles/JsonPath/> for supported operators.
-                        "#})),
+                .add_arg(query_arg.clone()),
         )
         .add_definition(
             Definition::new("flatten")
@@ -140,6 +145,15 @@ pub fn definitions<'a>() -> Definitions<'a> {
                     Recursively transforms all arrays into objects with the array index as key.
                 "#})
         )
+        .add_definition(
+            Definition::new("mutate")
+                .add_aliases(&["map"])
+                .with_description(indoc! {r#"
+                    Applies the expression to all values matched by the query and returns the
+                    mutated value.
+                "#})
+                .add_args(&[query_arg, expression_arg])
+        )
 }
 
 /// Parses expressions into a chain of transformations.
@@ -154,16 +168,16 @@ where
         .map(|expression| definitions.parse(expression.as_ref()))
         .collect::<Result<Vec<_>, dts_core::Error>>()?;
 
-    let chain = match_groups
-        .iter()
-        .flatten()
-        .map(match_transformation)
-        .collect::<Result<Vec<_>>>()?;
+    let expressions = match_groups.into_iter().flatten().collect::<Vec<_>>();
 
-    Ok(Chain::new(chain))
+    parse_matches(&expressions)
 }
 
-fn match_transformation(m: &DefinitionMatch<'_>) -> Result<Box<dyn Transform>> {
+fn parse_matches(matches: &[DefinitionMatch<'_>]) -> Result<Chain> {
+    matches.iter().map(parse_transformation).collect()
+}
+
+fn parse_transformation(m: &DefinitionMatch<'_>) -> Result<Box<dyn Transform>> {
     let transformation: Box<dyn Transform> = match m.name() {
         "arrays_to_objects" => Box::new(Transformation::ArraysToObjects),
         "deep_merge" => Box::new(Transformation::DeepMerge),
@@ -179,6 +193,12 @@ fn match_transformation(m: &DefinitionMatch<'_>) -> Result<Box<dyn Transform>> {
             let max_depth = m.value_of("max_depth").ok();
             let sorter = ValueSorter::new(order, max_depth);
             Box::new(Transformation::Sort(sorter))
+        }
+        "mutate" => {
+            let query: String = m.value_of("query")?;
+            let chain = m.map_expr_of("expression", parse_matches)?;
+            let mutator = JsonPathMutator::new(&query)?;
+            Box::new(Mutate::new(mutator, chain))
         }
         name => panic!("unmatched transformation `{}`, please file a bug", name),
     };


### PR DESCRIPTION
This PR adds `mutate` and the code to nest expressions. 

Example:

```
mutate("$.users[*].friends", sort())
```

Only sorts each user's friends by name but not the rest of the data structure.

This enables a whole lot of new ways to compose transformation functions and enables new use cases, for example:

```
replace("$.users[*].friends", ["paul", "dave"])
```

This one does not work right now because neither `replace` nor array syntax is supported, but it'll be fairly easy to implement after this PR is merged.