### PR TITLE
feat: add `State` to transform API

### DIFF
--- a/crates/dts-core/src/transform/dsl.rs
+++ b/crates/dts-core/src/transform/dsl.rs
@@ -213,6 +213,11 @@ impl<'a> Definition<'a> {
 impl<'a> fmt::Display for Definition<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.name)?;
+
+        if self.args.is_empty() {
+            return Ok(());
+        }
+
         f.write_char('(')?;
 
         let mut optional_args = 0;

--- a/crates/dts-core/src/transform/mod.rs
+++ b/crates/dts-core/src/transform/mod.rs
@@ -485,6 +485,10 @@ pub enum RingBuffer {
     PeekBack,
     /// Pop value from the back of the buffer.
     PopBack,
+    /// Peek all values from front-to-back.
+    PeekAll,
+    /// Pop all values from front-to-back.
+    PopAll,
 }
 
 impl Transform for RingBuffer {
@@ -504,6 +508,14 @@ impl Transform for RingBuffer {
             }
             RingBuffer::PeekBack => ringbuf.back().cloned(),
             RingBuffer::PopBack => ringbuf.pop_back(),
+            RingBuffer::PeekAll => Some(ringbuf.iter().cloned().collect()),
+            RingBuffer::PopAll => {
+                let mut vec = Vec::with_capacity(ringbuf.len());
+                while let Some(value) = ringbuf.pop_front() {
+                    vec.push(value);
+                }
+                Some(Value::Array(vec))
+            }
         };
 
         value.unwrap_or_default()

--- a/crates/dts-core/src/transform/state.rs
+++ b/crates/dts-core/src/transform/state.rs
@@ -1,0 +1,22 @@
+//! Types for carrying state across multiple transformations.
+
+use dts_json::Value;
+use std::collections::VecDeque;
+
+/// Represents the transform state.
+#[derive(Default)]
+pub struct State {
+    queue: VecDeque<Value>,
+}
+
+impl State {
+    /// Creates a new `State`.
+    pub fn new() -> Self {
+        State::default()
+    }
+
+    /// Returns a mutable reference to the underlying value queue.
+    pub fn queue_mut(&mut self) -> &mut VecDeque<Value> {
+        &mut self.queue
+    }
+}

--- a/crates/dts-core/src/transform/state.rs
+++ b/crates/dts-core/src/transform/state.rs
@@ -6,7 +6,7 @@ use std::collections::VecDeque;
 /// Represents the transform state.
 #[derive(Default)]
 pub struct State {
-    queue: VecDeque<Value>,
+    ringbuf: VecDeque<Value>,
 }
 
 impl State {
@@ -15,8 +15,8 @@ impl State {
         State::default()
     }
 
-    /// Returns a mutable reference to the underlying value queue.
-    pub fn queue_mut(&mut self) -> &mut VecDeque<Value> {
-        &mut self.queue
+    /// Returns a mutable reference to the underlying value ring buf.
+    pub fn ringbuf_mut(&mut self) -> &mut VecDeque<Value> {
+        &mut self.ringbuf
     }
 }

--- a/crates/dts-core/src/transform/state.rs
+++ b/crates/dts-core/src/transform/state.rs
@@ -6,7 +6,7 @@ use std::collections::VecDeque;
 /// Represents the transform state.
 #[derive(Default)]
 pub struct State {
-    ringbuf: VecDeque<Value>,
+    pub(crate) ringbuf: VecDeque<Value>,
 }
 
 impl State {

--- a/crates/dts-core/src/transform/visitor.rs
+++ b/crates/dts-core/src/transform/visitor.rs
@@ -1,6 +1,6 @@
 //! Provides types to visit elements of collections.
 
-use super::Transform;
+use super::{State, Transform};
 use dts_json::Value;
 
 /// A trait for visiting array values and key-value pairs of objects.
@@ -8,14 +8,14 @@ pub trait Visitor {
     /// Visits a key of an object and produces a new `String`.
     ///
     /// The default implementation just returns the key unchanged.
-    fn visit_key(&self, key: String) -> String {
+    fn visit_key(&self, key: String, _state: &mut State) -> String {
         key
     }
 
     /// Visits an array or object value and produces a new `Value`.
     ///
     /// The default implementation just returns the value unchanged.
-    fn visit_value(&self, value: Value) -> Value {
+    fn visit_value(&self, value: Value, _state: &mut State) -> Value {
         value
     }
 }
@@ -34,8 +34,8 @@ impl<T> Visitor for KeyVisitor<T>
 where
     T: Transform,
 {
-    fn visit_key(&self, key: String) -> String {
-        self.0.transform(key.into()).into_string()
+    fn visit_key(&self, key: String, state: &mut State) -> String {
+        self.0.transform(key.into(), state).into_string()
     }
 }
 
@@ -53,7 +53,7 @@ impl<T> Visitor for ValueVisitor<T>
 where
     T: Transform,
 {
-    fn visit_value(&self, value: Value) -> Value {
-        self.0.transform(value)
+    fn visit_value(&self, value: Value, state: &mut State) -> Value {
+        self.0.transform(value, state)
     }
 }

--- a/crates/dts/main.rs
+++ b/crates/dts/main.rs
@@ -21,7 +21,10 @@ use anyhow::{anyhow, Context, Result};
 use clap::{App, IntoApp, Parser};
 use clap_generate::{generate, Shell};
 use dts_core::{
-    de::Deserializer, ser::Serializer, transform::Transform, Encoding, Error, Sink, Source,
+    de::Deserializer,
+    ser::Serializer,
+    transform::{State, Transform},
+    Encoding, Error, Sink, Source,
 };
 use dts_json::Value;
 use rayon::prelude::*;
@@ -77,7 +80,7 @@ fn deserialize_many(sources: &[Source], opts: &InputOptions) -> Result<Value> {
 
 fn transform(value: Value, opts: &TransformOptions) -> Result<Value> {
     parse_expressions(&opts.expressions)
-        .map(|chain| chain.transform(value))
+        .map(|chain| chain.transform(value, &mut State::new()))
         .context("Failed to build transformation chain")
 }
 

--- a/crates/dts/transform.rs
+++ b/crates/dts/transform.rs
@@ -272,10 +272,24 @@ pub fn definitions<'a>() -> Definitions<'a> {
                 .add_arg(&expression_arg)
         )
         .add_definition(
-            Definition::new("push_front")
+            Definition::new("peek_all_back")
                 .with_description(indoc! {r#"
-                    Pushes the current value to the front of the ring buffer. Returns the current
-                    value unaltered.
+                    Peeks all values from the ring buffer back-to-front without taking them out and
+                    returns them as an array.
+                "#})
+        )
+        .add_definition(
+            Definition::new("peek_all_front")
+                .with_description(indoc! {r#"
+                    Peeks all values from the ring buffer front-to-back without taking them out and
+                    returns them as an array.
+                "#})
+        )
+        .add_definition(
+            Definition::new("peek_back")
+                .with_description(indoc! {r#"
+                    Peeks the value from the back of the ring buffer without taking it out. If the
+                    buffer is empty, the value will be null.
                 "#})
         )
         .add_definition(
@@ -283,6 +297,25 @@ pub fn definitions<'a>() -> Definitions<'a> {
                 .with_description(indoc! {r#"
                     Peeks the value from the front of the ring buffer without taking it out. If the
                     buffer is empty, the value will be null.
+                "#})
+        )
+        .add_definition(
+            Definition::new("pop_all_back")
+                .with_description(indoc !{r#"
+                    Pops all values from the ring buffer back-to-front and returns them as an array.
+                "#})
+        )
+        .add_definition(
+            Definition::new("pop_all_front")
+                .with_description(indoc !{r#"
+                    Pops all values from the ring buffer front-to-back and returns them as an array.
+                "#})
+        )
+        .add_definition(
+            Definition::new("pop_back")
+                .with_description(indoc! {r#"
+                    Pops the value from the back of the ring buffer. If the buffer is empty, the
+                    value will be null.
                 "#})
         )
         .add_definition(
@@ -300,30 +333,10 @@ pub fn definitions<'a>() -> Definitions<'a> {
                 "#})
         )
         .add_definition(
-            Definition::new("peek_back")
+            Definition::new("push_front")
                 .with_description(indoc! {r#"
-                    Peeks the value from the back of the ring buffer without taking it out. If the
-                    buffer is empty, the value will be null.
-                "#})
-        )
-        .add_definition(
-            Definition::new("pop_back")
-                .with_description(indoc! {r#"
-                    Pops the value from the back of the ring buffer. If the buffer is empty, the
-                    value will be null.
-                "#})
-        )
-        .add_definition(
-            Definition::new("peek_all")
-                .with_description(indoc! {r#"
-                    Peeks all values from the ring buffer front-to-back without taking them out and
-                    returns them as an array.
-                "#})
-        )
-        .add_definition(
-            Definition::new("pop_all")
-                .with_description(indoc !{r#"
-                    Pops all values from the ring buffer front-to-back and returns them as an array.
+                    Pushes the current value to the front of the ring buffer. Returns the current
+                    value unaltered.
                 "#})
         )
 }
@@ -372,14 +385,16 @@ fn parse_transformation(m: &DefinitionMatch<'_>) -> Result<Box<dyn Transform>> {
             let chain = m.map_expr("expression", parse_matches)?;
             Box::new(Mutate::new(mutator, chain))
         }
-        "push_front" => Box::new(RingBuffer::PushFront),
+        "peek_all_back" => Box::new(RingBuffer::PeekAllBack),
+        "peek_all_front" => Box::new(RingBuffer::PeekAllFront),
+        "peek_back" => Box::new(RingBuffer::PeekBack),
         "peek_front" => Box::new(RingBuffer::PeekFront),
+        "pop_all_back" => Box::new(RingBuffer::PopAllBack),
+        "pop_all_front" => Box::new(RingBuffer::PopAllFront),
+        "pop_back" => Box::new(RingBuffer::PopBack),
         "pop_front" => Box::new(RingBuffer::PopFront),
         "push_back" => Box::new(RingBuffer::PushBack),
-        "peek_back" => Box::new(RingBuffer::PeekBack),
-        "pop_back" => Box::new(RingBuffer::PopBack),
-        "peek_all" => Box::new(RingBuffer::PeekAll),
-        "pop_all" => Box::new(RingBuffer::PopAll),
+        "push_front" => Box::new(RingBuffer::PushFront),
         "remove" => Box::new(Remove::new(m.parse_str("query")?)),
         "remove_empty_values" => Box::new(Unparameterized::RemoveEmptyValues),
         "replace_string" => {

--- a/crates/dts/transform.rs
+++ b/crates/dts/transform.rs
@@ -274,7 +274,8 @@ pub fn definitions<'a>() -> Definitions<'a> {
         .add_definition(
             Definition::new("push_front")
                 .with_description(indoc! {r#"
-                    Pushes the current value to the front of the ring buffer.
+                    Pushes the current value to the front of the ring buffer. Returns the current
+                    value unaltered.
                 "#})
         )
         .add_definition(
@@ -294,7 +295,8 @@ pub fn definitions<'a>() -> Definitions<'a> {
         .add_definition(
             Definition::new("push_back")
                 .with_description(indoc! {r#"
-                    Pushes the current value to the back of the ring buffer.
+                    Pushes the current value to the back of the ring buffer. Returns the current
+                    value unaltered.
                 "#})
         )
         .add_definition(
@@ -309,6 +311,19 @@ pub fn definitions<'a>() -> Definitions<'a> {
                 .with_description(indoc! {r#"
                     Pops the value from the back of the ring buffer. If the buffer is empty, the
                     value will be null.
+                "#})
+        )
+        .add_definition(
+            Definition::new("peek_all")
+                .with_description(indoc! {r#"
+                    Peeks all values from the ring buffer front-to-back without taking them out and
+                    returns them as an array.
+                "#})
+        )
+        .add_definition(
+            Definition::new("pop_all")
+                .with_description(indoc !{r#"
+                    Pops all values from the ring buffer front-to-back and returns them as an array.
                 "#})
         )
 }
@@ -363,6 +378,8 @@ fn parse_transformation(m: &DefinitionMatch<'_>) -> Result<Box<dyn Transform>> {
         "push_back" => Box::new(RingBuffer::PushBack),
         "peek_back" => Box::new(RingBuffer::PeekBack),
         "pop_back" => Box::new(RingBuffer::PopBack),
+        "peek_all" => Box::new(RingBuffer::PeekAll),
+        "pop_all" => Box::new(RingBuffer::PopAll),
         "remove" => Box::new(Remove::new(m.parse_str("query")?)),
         "remove_empty_values" => Box::new(Unparameterized::RemoveEmptyValues),
         "replace_string" => {

--- a/crates/dts/transform.rs
+++ b/crates/dts/transform.rs
@@ -5,7 +5,7 @@ use dts_core::transform::{
     sort::ValueSorter,
     visitor::{KeyVisitor, ValueVisitor},
     Chain, Delete, DeleteKeys, EachKey, EachValue, FlattenKeys, Insert, KeyIndex, Mutate, Remove,
-    ReplaceString, Select, Sort, Transform, Unparameterized, Visit, Wrap,
+    ReplaceString, RingBuffer, Select, Sort, Transform, Unparameterized, Visit, Wrap,
 };
 use indoc::indoc;
 use std::convert::TryFrom;
@@ -271,6 +271,46 @@ pub fn definitions<'a>() -> Definitions<'a> {
                 )
                 .add_arg(&expression_arg)
         )
+        .add_definition(
+            Definition::new("push_front")
+                .with_description(indoc! {r#"
+                    Pushes the current value to the front of the ring buffer.
+                "#})
+        )
+        .add_definition(
+            Definition::new("peek_front")
+                .with_description(indoc! {r#"
+                    Peeks the value from the front of the ring buffer without taking it out. If the
+                    buffer is empty, the value will be null.
+                "#})
+        )
+        .add_definition(
+            Definition::new("pop_front")
+                .with_description(indoc! {r#"
+                    Pops the value from the front of the ring buffer. If the buffer is empty, the
+                    value will be null.
+                "#})
+        )
+        .add_definition(
+            Definition::new("push_back")
+                .with_description(indoc! {r#"
+                    Pushes the current value to the back of the ring buffer.
+                "#})
+        )
+        .add_definition(
+            Definition::new("peek_back")
+                .with_description(indoc! {r#"
+                    Peeks the value from the back of the ring buffer without taking it out. If the
+                    buffer is empty, the value will be null.
+                "#})
+        )
+        .add_definition(
+            Definition::new("pop_back")
+                .with_description(indoc! {r#"
+                    Pops the value from the back of the ring buffer. If the buffer is empty, the
+                    value will be null.
+                "#})
+        )
 }
 
 /// Parses expressions into a chain of transformations.
@@ -317,6 +357,12 @@ fn parse_transformation(m: &DefinitionMatch<'_>) -> Result<Box<dyn Transform>> {
             let chain = m.map_expr("expression", parse_matches)?;
             Box::new(Mutate::new(mutator, chain))
         }
+        "push_front" => Box::new(RingBuffer::PushFront),
+        "peek_front" => Box::new(RingBuffer::PeekFront),
+        "pop_front" => Box::new(RingBuffer::PopFront),
+        "push_back" => Box::new(RingBuffer::PushBack),
+        "peek_back" => Box::new(RingBuffer::PeekBack),
+        "pop_back" => Box::new(RingBuffer::PopBack),
         "remove" => Box::new(Remove::new(m.parse_str("query")?)),
         "remove_empty_values" => Box::new(Unparameterized::RemoveEmptyValues),
         "replace_string" => {


### PR DESCRIPTION
This allows to access a ring buffer to push and pop values during transformation. One use case is to insert values found in a certain place in the tree in a different location.

For example, this:

```sh
dts -t 'each_key(push_front).each_value(insert("key", pop_back)).values'
```

converts this:

```json
{
  "foo": {
    "bar": "baz"
  },
  "one": {
    "two": "three"
  }
}
```

into this:

```json
[
  {
    "bar": "baz",
    "key": "foo"
  },
  {
    "two": "three",
    "key": "one"
  }
]
```