### PR TITLE
feat: detect encoding from first line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,6 +478,7 @@ dependencies = [
  "glob",
  "hcl",
  "json5",
+ "once_cell",
  "pathdiff",
  "pest",
  "pest_derive",

--- a/crates/dts-core/Cargo.toml
+++ b/crates/dts-core/Cargo.toml
@@ -9,6 +9,7 @@ glob = "0.3.0"
 hcl = { path = "../hcl" }
 dts-json = { path = "../dts-json" }
 json5 = "0.4.1"
+once_cell = "1.9.0"
 pathdiff = "0.2.1"
 regex = "1.5.4"
 serde-xml-rs = "0.5.1"

--- a/crates/dts-core/src/encoding.rs
+++ b/crates/dts-core/src/encoding.rs
@@ -1,6 +1,8 @@
 //! Supported encodings for serialization and deserialization.
 
 use clap::ArgEnum;
+use once_cell::sync::Lazy;
+use regex::Regex;
 use std::fmt;
 use std::path::Path;
 
@@ -37,6 +39,66 @@ pub enum Encoding {
     Hcl,
 }
 
+// Patterns to detect a source encoding by looking at the first line of input. The patterns are
+// lazily constructed upon first usage as they are only needed if there is no other encoding hint
+// (e.g. encoding inferred from file extension or explicitly provided on the command line).
+//
+// These patterns are very basic and will only detect some of the more common first lines. Thus
+// they may not match valid pattern for a given encoding on purpose due to ambiguities. For example
+// the first line `["foo"]` may be a JSON array or a TOML table header. Make sure to avoid matching
+// anything that is ambiguous.
+static FIRST_LINES: Lazy<Vec<(Encoding, Regex)>> = Lazy::new(|| {
+    vec![
+        // XML or HTML start.
+        (
+            Encoding::Xml,
+            Regex::new(
+                r#"^(?x:
+                    <\?xml\s
+                    | \s*<(?:[\w-]+):Envelope\s+
+                    | \s*(?i:<!DOCTYPE\s+)
+                )"#,
+            )
+            .unwrap(),
+        ),
+        // HCL block start of the form
+        //
+        //   <identifier> [<identifier>|<quoted-string>]* {
+        //
+        // Expression for matching quoted strings is very basic.
+        (
+            Encoding::Hcl,
+            Regex::new(
+                r#"^(?xi:
+                    [a-z_][a-z0-9_-]*\s+
+                    (?:(?:[a-z_][a-z0-9_-]*|"[^"]*")\s+)*\{
+                )"#,
+            )
+            .unwrap(),
+        ),
+        // YAML document start or document separator.
+        (Encoding::Yaml, Regex::new(r"^(?:%YAML.*|---\s*)$").unwrap()),
+        // TOML array of tables or table.
+        (
+            Encoding::Toml,
+            Regex::new(
+                r#"^(?xi:
+                    # array of tables
+                    \[\[\s*[a-z0-9_-]+(?:\s*\.\s*(?:[a-z0-9_-]+|"[^"]*"))*\s*\]\]\s*
+                    # table
+                    | \[\s*[a-z0-9_-]+(?:\s*\.\s*(?:[a-z0-9_-]+|"[^"]*"))*\s*\]\s*
+                )$"#,
+            )
+            .unwrap(),
+        ),
+        // JSON object start or array start.
+        (
+            Encoding::Json,
+            Regex::new(r#"^(?:\{\s*(?:"|$)|\[\s*$)"#).unwrap(),
+        ),
+    ]
+});
+
 impl Encoding {
     /// Creates an `Encoding` from a path by looking at the file extension.
     ///
@@ -59,6 +121,24 @@ impl Encoding {
             "hcl" | "tf" => Some(Encoding::Hcl),
             _ => None,
         }
+    }
+
+    /// Tries to detect the `Encoding` by looking at the first line of the input.
+    ///
+    /// Returns `None` if the encoding cannot be detected from the first line.
+    pub fn from_first_line(line: &str) -> Option<Encoding> {
+        if line.is_empty() {
+            // Fast path.
+            return None;
+        }
+
+        for (encoding, regex) in FIRST_LINES.iter() {
+            if regex.is_match(line) {
+                return Some(*encoding);
+            }
+        }
+
+        None
     }
 
     /// Returns the name of the `Encoding`.
@@ -98,5 +178,47 @@ mod tests {
         assert_eq!(Encoding::from_path("foo.toml"), Some(Encoding::Toml));
         assert_eq!(Encoding::from_path("foo.bak"), None);
         assert_eq!(Encoding::from_path("foo"), None);
+    }
+
+    #[test]
+    fn test_encoding_from_first_line() {
+        // no match
+        assert_eq!(Encoding::from_first_line(""), None);
+        assert_eq!(Encoding::from_first_line(r#"["foo"]"#), None);
+
+        // match
+        assert_eq!(
+            Encoding::from_first_line(r#"resource "aws_s3_bucket" "my-bucket" {"#),
+            Some(Encoding::Hcl)
+        );
+        assert_eq!(Encoding::from_first_line("{ "), Some(Encoding::Json));
+        assert_eq!(Encoding::from_first_line("[ "), Some(Encoding::Json));
+        assert_eq!(
+            Encoding::from_first_line(r#"{"foo": 1 }"#),
+            Some(Encoding::Json)
+        );
+        assert_eq!(
+            Encoding::from_first_line(r#"[foo .bar."baz".qux]"#),
+            Some(Encoding::Toml)
+        );
+        assert_eq!(
+            Encoding::from_first_line(r#"[[foo .bar."baz".qux]] "#),
+            Some(Encoding::Toml)
+        );
+        assert_eq!(Encoding::from_first_line("%YAML 1.2"), Some(Encoding::Yaml));
+        assert_eq!(
+            Encoding::from_first_line("<!doctype html>"),
+            Some(Encoding::Xml)
+        );
+        assert_eq!(
+            Encoding::from_first_line(r#"<?xml version="1.0" ?>"#),
+            Some(Encoding::Xml)
+        );
+        assert_eq!(
+            Encoding::from_first_line(
+                r#"<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope/" soap:encodingStyle="http://www.w3.org/2003/05/soap-encoding">"#
+            ),
+            Some(Encoding::Xml)
+        );
     }
 }

--- a/crates/dts-core/src/lib.rs
+++ b/crates/dts-core/src/lib.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 pub use encoding::*;
 pub use error::*;
 pub use sink::Sink;
-pub use source::Source;
+pub use source::{Source, SourceReader};
 
 pub mod de;
 mod encoding;

--- a/crates/dts/args.rs
+++ b/crates/dts/args.rs
@@ -66,7 +66,10 @@ pub struct Options {
 #[derive(Args, Debug)]
 #[clap(help_heading = "INPUT OPTIONS")]
 pub struct InputOptions {
-    /// Set the input encoding. If absent encoding will be detected from input file extension.
+    /// Set the input encoding.
+    ///
+    /// If absent, dts will attempt to detect the encoding from the input file extension (if
+    /// present) or the first line of input.
     #[clap(arg_enum, short = 'i', long, setting = ArgSettings::HidePossibleValues)]
     pub input_encoding: Option<Encoding>,
 
@@ -152,7 +155,9 @@ pub struct TransformOptions {
 #[derive(Args, Debug)]
 #[clap(help_heading = "OUTPUT OPTIONS")]
 pub struct OutputOptions {
-    /// Set the output encoding. If absent encoding will be detected from output file extension.
+    /// Set the output encoding.
+    ///
+    /// If absent, the encoding will be detected from output file extension.
     ///
     /// If the encoding is not explicitly set and it cannot be inferred from the output file
     /// extension (or the output is stdout), the fallback is to encode output as JSON.

--- a/crates/dts/main.rs
+++ b/crates/dts/main.rs
@@ -22,19 +22,19 @@ use dts_core::{de::Deserializer, jq::Jq, ser::Serializer, Encoding, Error, Sink,
 use dts_json::Value;
 use rayon::prelude::*;
 use std::fs::File;
-use std::io::{self, BufReader, BufWriter};
+use std::io::{self, BufWriter};
 
 fn deserialize(source: &Source, opts: &InputOptions) -> Result<Value> {
-    let encoding = opts
-        .input_encoding
-        .or_else(|| source.encoding())
-        .context("Unable to detect input encoding, please provide it explicitly via -i")?;
-
     let reader = source
         .to_reader()
         .with_context(|| format!("Failed to create reader for source `{}`", source))?;
 
-    let mut de = Deserializer::with_options(BufReader::new(reader), opts.into());
+    let encoding = opts
+        .input_encoding
+        .or_else(|| reader.encoding())
+        .context("Unable to detect input encoding, please provide it explicitly via -i")?;
+
+    let mut de = Deserializer::with_options(reader, opts.into());
 
     de.deserialize(encoding)
         .with_context(|| format!("Failed to deserialize `{}` from `{}`", encoding, source))

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -95,13 +95,23 @@ fn gron_to_json() {
 fn encoding_required_for_stdin() {
     Command::cargo_bin("dts")
         .unwrap()
-        .pipe_stdin("tests/fixtures/example.json")
+        .pipe_stdin("tests/fixtures/example.js")
         .unwrap()
         .assert()
         .failure()
         .stderr(predicate::str::contains(
             "Unable to detect input encoding, please provide it explicitly via -i",
         ));
+}
+
+#[test]
+fn encoding_inferred_from_first_line() {
+    Command::cargo_bin("dts")
+        .unwrap()
+        .pipe_stdin("tests/fixtures/example.json")
+        .unwrap()
+        .assert()
+        .success();
 }
 
 #[test]


### PR DESCRIPTION
Adds a `SourceReader` which extracts the first line of input in order to
use it for detecting the encoding for a set of relatively basic regex
patterns.

Please note, that the first line detection is only triggered if the `-i`
flag was not explicitly provided and one of the following conditions
applies:

- The input is provided via stdin.
- The input is coming from a file or url and the file extension is
  either absent or unknown to dts.