### PR TITLE
fix(errors): use lowercase sentences

### DIFF
--- a/crates/dts-core/src/error.rs
+++ b/crates/dts-core/src/error.rs
@@ -18,7 +18,7 @@ pub enum Error {
     Message(String),
 
     /// Represents errors of operations that are not supported by a certain encoding.
-    #[error("Operation is not supported for encoding `{0}`")]
+    #[error("operation is not supported for encoding `{0}`")]
     UnsupportedEncoding(Encoding),
 
     /// Error emitted by parsers from this crate.
@@ -34,7 +34,7 @@ pub enum Error {
     Io(#[from] io::Error),
 
     /// Represents an invalid glob pattern.
-    #[error("Invalid glob pattern `{pattern}`")]
+    #[error("invalid glob pattern `{pattern}`")]
     GlobPatternError {
         /// The pattern that caused the error.
         pattern: String,
@@ -43,7 +43,7 @@ pub enum Error {
     },
 
     /// Represents an error fetching a remote data source.
-    #[error("Unable to fetch remote data source")]
+    #[error("unable to fetch remote data source")]
     RequestError(#[from] ureq::Error),
 
     /// Represents errors emitted by serializers and deserializers.

--- a/crates/dts-core/src/jq.rs
+++ b/crates/dts-core/src/jq.rs
@@ -20,11 +20,11 @@ pub enum Error {
     Unknown(String),
 
     /// Returned if the executable is not found.
-    #[error("Executable `{}` not found", .0.display())]
+    #[error("executable `{}` not found", .0.display())]
     ExecutableNotFound(PathBuf),
 
     /// Returned if the executable exists but does not appear to be `jq`.
-    #[error("Executable `{}` exists but does appear to be `jq`", .0.display())]
+    #[error("executable `{}` exists but does appear to be `jq`", .0.display())]
     InvalidExecutable(PathBuf),
 
     /// Represents generic IO errors.

--- a/crates/dts-core/src/parsers/error.rs
+++ b/crates/dts-core/src/parsers/error.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 /// Error emitted by all parsers in this module.
 #[derive(Error, Debug)]
-#[error("Failed to parse {kind}:\n{msg}")]
+#[error("failed to parse {kind}:\n{msg}")]
 pub struct ParseError {
     kind: ParseErrorKind,
     msg: String,

--- a/crates/dts-core/src/source.rs
+++ b/crates/dts-core/src/source.rs
@@ -55,7 +55,7 @@ impl Source {
                 .iter()
                 .map(|path| Self::from(path.as_path()))
                 .collect()),
-            None => Err(Error::new("Not a path source")),
+            None => Err(Error::new("not a path source")),
         }
     }
 

--- a/crates/dts/main.rs
+++ b/crates/dts/main.rs
@@ -27,17 +27,17 @@ use std::io::{self, BufWriter};
 fn deserialize(source: &Source, opts: &InputOptions) -> Result<Value> {
     let reader = source
         .to_reader()
-        .with_context(|| format!("Failed to create reader for source `{}`", source))?;
+        .with_context(|| format!("failed to create reader for source `{}`", source))?;
 
     let encoding = opts
         .input_encoding
         .or_else(|| reader.encoding())
-        .context("Unable to detect input encoding, please provide it explicitly via -i")?;
+        .context("unable to detect input encoding, please provide it explicitly via -i")?;
 
     let mut de = Deserializer::with_options(reader, opts.into());
 
     de.deserialize(encoding)
-        .with_context(|| format!("Failed to deserialize `{}` from `{}`", encoding, source))
+        .with_context(|| format!("failed to deserialize `{}` from `{}`", encoding, source))
 }
 
 fn deserialize_many(sources: &[Source], opts: &InputOptions) -> Result<Value> {
@@ -79,7 +79,7 @@ fn transform(value: Value, opts: &TransformOptions) -> Result<Value> {
                 .map(Jq::with_executable)
                 .unwrap_or_else(Jq::new)
                 .context(
-                    "Install `jq` or provide the `jq` executable path \
+                    "install `jq` or provide the `jq` executable path \
                     in the `DTS_JQ` environment variable",
                 )?;
 
@@ -88,7 +88,7 @@ fn transform(value: Value, opts: &TransformOptions) -> Result<Value> {
                 None => jq.process(expr, &value),
             };
 
-            res.context("Failed to transform value")
+            res.context("failed to transform value")
         }
         None => Ok(value),
     }
@@ -116,7 +116,7 @@ fn serialize(sink: &Sink, value: Value, opts: &OutputOptions) -> Result<()> {
         Sink::Stdout => Box::new(StdoutWriter::new(paging_config)),
         Sink::Path(path) => Box::new(
             File::create(path)
-                .with_context(|| format!("Failed to create writer for sink `{}`", sink))?,
+                .with_context(|| format!("failed to create writer for sink `{}`", sink))?,
         ),
     };
 
@@ -127,7 +127,7 @@ fn serialize(sink: &Sink, value: Value, opts: &OutputOptions) -> Result<()> {
         Err(Error::Io(err)) if err.kind() == io::ErrorKind::BrokenPipe => Ok(()),
         Err(err) => Err(err),
     }
-    .with_context(|| format!("Failed to serialize `{}` to `{}`", encoding, sink))
+    .with_context(|| format!("failed to serialize `{}` to `{}`", encoding, sink))
 }
 
 fn serialize_many(sinks: &[Sink], value: Value, opts: &OutputOptions) -> Result<()> {
@@ -144,14 +144,14 @@ fn serialize_many(sinks: &[Sink], value: Value, opts: &OutputOptions) -> Result<
         }
         _ => {
             return Err(anyhow!(
-                "When using multiple output files, the data must be an array"
+                "when using multiple output files, the data must be an array"
             ))
         }
     };
 
     if sinks.len() > values.len() {
         eprintln!(
-            "Warning: Skipping {} output files due to lack of data",
+            "Warning: skipping {} output files due to lack of data",
             sinks.len() - values.len()
         );
     }
@@ -226,12 +226,12 @@ fn main() -> Result<()> {
 
             if !path.is_file() {
                 return Err(anyhow!(
-                    "Output file `{}` exists but is not a file",
+                    "output file `{}` exists but is not a file",
                     path.display()
                 ));
             } else if !opts.output.overwrite {
                 return Err(anyhow!(
-                    "Output file `{}` exists, pass --overwrite to overwrite it",
+                    "output file `{}` exists, pass --overwrite to overwrite it",
                     path.display()
                 ));
             }
@@ -239,7 +239,7 @@ fn main() -> Result<()> {
     }
 
     let value = match (sources.len(), dir_sources) {
-        (0, false) => return Err(anyhow!("Input file or data on stdin expected")),
+        (0, false) => return Err(anyhow!("input file or data on stdin expected")),
         (1, false) => deserialize(&sources[0], &opts.input)?,
         (_, _) => deserialize_many(&sources, &opts.input)?,
     };

--- a/crates/hcl/src/error.rs
+++ b/crates/hcl/src/error.rs
@@ -56,7 +56,7 @@ impl Error {
     where
         T: Display,
     {
-        Error::new_span(format!("Expected `{}`", token), span)
+        Error::new_span(format!("expected `{}`", token), span)
     }
 
     pub(crate) fn with_span(self, span: Option<Span<'_>>) -> Error {
@@ -84,7 +84,7 @@ impl Error {
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Eof => write!(f, "Unexpected end of input"),
+            Error::Eof => write!(f, "unexpected end of input"),
             Error::Io(err) => Display::fmt(err, f),
             Error::Message { msg, location } => match location {
                 Some(loc) => {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -100,7 +100,7 @@ fn encoding_required_for_stdin() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "Unable to detect input encoding, please provide it explicitly via -i",
+            "unable to detect input encoding, please provide it explicitly via -i",
         ));
 }
 
@@ -123,7 +123,7 @@ fn multiple_sinks_require_array() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "When using multiple output files, the data must be an array",
+            "when using multiple output files, the data must be an array",
         ));
 }
 


### PR DESCRIPTION
Since the stdlib docs suggest to use lowercase sentences as error
messages this change adjusts all error messages to start with a
lowercase letter.

See: https://doc.rust-lang.org/std/error/trait.Error.html