### PR TITLE
ci: add `publish-crates.sh`

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,10 +3,14 @@ name: release-please
 on:
   workflow_dispatch:
     inputs:
-      force-publish:
+      force-publish-crates:
         required: true
         type: boolean
-        description: Publish artifacts even if no new release was created.
+        description: Publish crates even if no new release was created.
+      force-publish-packages:
+        required: true
+        type: boolean
+        description: Publish packages even if no new release was created.
   push:
     branches:
       - main
@@ -25,7 +29,7 @@ jobs:
 
   publish-crates:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created || github.event.inputs.force-publish }}
+    if: ${{ needs.release-please.outputs.release_created || github.event.inputs.force-publish-crates }}
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
@@ -41,13 +45,11 @@ jobs:
       - name: Publish to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          cargo publish --package dts-core || true
-          cargo publish --package dts || true
+        run: scripts/publish-crates.sh
 
   publish-packages:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created || github.event.inputs.force-publish }}
+    if: ${{ needs.release-please.outputs.release_created || github.event.inputs.force-publish-packages }}
     name: Package ${{ matrix.target }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     env:

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+#
+# Packages up releases as tar archives.
 
 set -euo pipefail
 

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Publishes crates to crates.io.
+#
+# The scripts accepts additional arguments for `cargo publish`.
+
+set -euo pipefail
+
+# Dependencies need to be published first.
+declare -a crates=("dts-core" "dts")
+
+declare -a log_files=()
+
+cleanup() {
+  for log_file in "${log_files[@]}"; do
+    rm -f "$log_file"
+  done
+}
+
+publish_crate() {
+  local crate="$1"; shift
+  local cargo_args=("$@")
+  local log_file
+  local -i ret=0
+  local -i attempt_num=1
+  local -i max_attempts=5
+
+  while true; do
+    log_file="$(mktemp -t cargo-log.XXXXXXX)"
+    log_files+=("$log_file")
+
+    set +e
+    cargo publish --package "$crate" "${cargo_args[@]}" 2>&1 | tee "$log_file"
+    ret=$?
+    set -e
+
+    if [ $ret -eq 0 ] || grep -q "already uploaded" "$log_file"; then
+      # All good.
+      return 0
+    fi
+
+    # Only retry version requirement issues. This may mean that a just
+    # uploaded crate version is not visible to cargo yet.
+    if ! grep -q "failed to select a version for the requirement" "$log_file"; then
+      return $ret
+    fi
+
+    if [ $attempt_num -ge $max_attempts ]; then
+      break
+    fi
+
+    echo "Retrying in $attempt_num seconds..."
+    sleep $((attempt_num++))
+  done
+
+  return $ret
+}
+
+publish() {
+  for crate in "${crates[@]}"; do
+    publish_crate "$crate" "$@"
+  done
+}
+
+trap cleanup EXIT
+
+publish "$@"


### PR DESCRIPTION
The script gracefully handles already published crate versions and will
retry publishing if a dependency version is not visible on crates.io
yet.