### PR TITLE
fix: remove `strip` feature from release profile

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -83,6 +83,12 @@ jobs:
         shell: bash
         run: |
           case ${{ matrix.target }} in
+            arm-unknown-linux-*)
+              sudo apt-get -y update
+              sudo apt-get -y install gcc-arm-linux-gnueabihf ;;
+            aarch64-unknown-linux-gnu)
+              sudo apt-get -y update
+              sudo apt-get -y install gcc-aarch64-linux-gnu ;;
             *-darwin)
               brew install coreutils ;;
           esac

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,4 +74,3 @@ path = "tests/integration_tests.rs"
 codegen-units = 1
 lto = true
 opt-level = "s"
-strip = true


### PR DESCRIPTION
This partially reverts #53 since it broke dependabot which still uses cargo 1.58.0 where the `strip` feature is not stabilized.

This shouldn't change anything for the resulting binaries since we still keep the release profile options added in #53 and only revert back to stripping the release binaries manually.