### PR TITLE
feat: enable `jaq` feature by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [features]
-default = ["color"]
+default = ["color", "jaq"]
 color = ["bat", "bat/paging", "clap/color"]
 jaq = ["jaq-core", "jaq-std"]
 

--- a/README.md
+++ b/README.md
@@ -125,9 +125,8 @@ The following feature flags are available:
   environment variable or set `DTS_COLOR=never`.
 
 * `jaq`: Use [`jaq-core`](https://docs.rs/jaq-core/latest/jaq_core/) to
-  process transformation filters instead of shelling out to `jq`.
-
-  This feature is experimental and not enabled by default yet.
+  process transformation filters instead of shelling out to `jq`. This feature
+  is enabled by default.
 
 ## License
 


### PR DESCRIPTION
`jaq` is mature enough now to be used by default. This also gets rid of the dependency to the `jq` binary which might not be present everywhere.